### PR TITLE
fix: resolve mobile button click issue by updating z-index and pointe…

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
             <Navbar variant='default' />
 
             {/* Hero Section */}
-            <section className='py-20 sm:py-32'>
+            <section className='py-20 sm:py-32 relative z-[2]'>
                 <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
                     <div className='text-center'>
                         <div className='mb-8 flex justify-center'>
@@ -84,8 +84,8 @@ export default function Home() {
                 </div>
 
                 {/* Decorative Elements */}
-                <div className='absolute top-0 left-0 w-72 h-72 bg-orange-200 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-pulse'></div>
-                <div className='absolute bottom-0 right-0 w-72 h-72 bg-green-200 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-pulse delay-1000'></div>
+                <div className='absolute top-0 left-0 w-72 h-72 bg-orange-200 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-pulse z-[1] pointer-events-none'></div>
+                <div className='absolute bottom-0 right-0 w-72 h-72 bg-green-200 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-pulse delay-1000 z-[1] pointer-events-none'></div>
             </section>
 
             {/* Why We're Building Section */}

--- a/frontend/components/ui/Button.tsx
+++ b/frontend/components/ui/Button.tsx
@@ -67,10 +67,11 @@ export default function Button(props: ButtonProps) {
             {isLoading ? (
                 <div className='mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent' />
             ) : leftIcon ? (
-                <span className='mr-2'>{leftIcon}</span>
+                <span className='mr-2 pointer-events-none'>{leftIcon}</span>
             ) : null}
             {children}
-            {rightIcon && <span className='ml-2'>{rightIcon}</span>}
+            {rightIcon && (<span className='ml-2 pointer-events-none'>{rightIcon}</span>
+)}
         </>
     )
 
@@ -91,8 +92,10 @@ export default function Button(props: ButtonProps) {
         }
 
         return (
-            <Link href={href} className={classes} {...(linkProps as any)}>
+            <Link href={href} legacyBehavior>
+            <a className={classes} {...(linkProps as any)}>
                 {content}
+            </a>
             </Link>
         )
     }


### PR DESCRIPTION
## Summary
This PR fixes an issue where the **"View Dashboard"** and **"View on GitHub"** buttons
on the home page were not fully clickable on mobile devices.  
Tapping only worked on the extreme left side of the button.

After debugging, this was caused by:

- Decorative blurred background blobs using `absolute` positioning
- Blobs creating a higher stacking context over the hero buttons on mobile layouts
- Icons inside the Button component sometimes intercepting pointer events
- Missing pointer event handling on decorative layers

This PR improves the mobile UX without changing any visible UI.
Resolves: #77 #78 
---

Before fix -
https://github.com/user-attachments/assets/03cc9a6e-6ec8-4701-8cb4-c37fd08d125f

After fix -
https://github.com/user-attachments/assets/9c12c124-08bb-46e6-ae74-86e1b3c1234a

## Fixes Implemented
### 🔧 1. Prevent Background Blobs From Blocking Touch
Added:
pointer-events-none
