### PR TITLE
Limit api request limit parameter to a maximum of 200

### DIFF
--- a/app/routes/api_routes.py
+++ b/app/routes/api_routes.py
@@ -31,7 +31,7 @@ def list_politicians():
     """
     try:
         election_type = request.args.get("type")
-        limit = request.args.get("limit", default=100, type=int)
+        limit = min(request.args.get("limit", default=100, type=int),200)
         result = politician_ctrl.get_all(election_type=election_type, limit=limit)
         return jsonify({"success": True, "data": result})
     except Exception as e:


### PR DESCRIPTION
Added maximum limit validation to prevent large API queries


Currently there is no upper bound for the request being accepted.This allows extremely large requests (eg: limit=100000),which may lead to high db load and slower API response.To address this a capping of 200 is implemented per request.