### PR TITLE
Add MLA data for 8 missing states (867 MLAs)

### DIFF
--- a/app/data/mla.json
+++ b/app/data/mla.json
@@ -45967,5 +45967,17345 @@
       "summary": null
     },
     "notes": null
+  },
+  {
+    "id": "716c7ea5-c2b7-5fd6-8b5e-5857028118cc",
+    "name": "BHUWAN CHANDRA KAPRI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Khatima",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Khatima",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb0789f0-6976-50ad-a10f-18fc05a581fd",
+    "name": "GOPAL SINGH RANA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Nanak Matta",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Nanak Matta",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb9e86b8-f071-5ea8-8a4d-26276a7f14ba",
+    "name": "SAURABH BAHUGUNA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Sitarganj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Sitarganj",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c0eac762-62b9-55ce-8c86-2ba1a5ac81df",
+    "name": "TILAK RAJ BEHAR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Kichha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Kichha",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "434fb05e-b469-5e26-8146-8f53ba0a4bcd",
+    "name": "SHIV ARORA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Rudrapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Rudrapur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dda8e918-64d7-58e1-890e-96fbad1cddbd",
+    "name": "ARVIND PANDEY",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Gadarpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Gadarpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "544cda66-0708-5fa3-9f74-a39e86d55678",
+    "name": "YASHPAL ARYA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Bajpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Bajpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8d3d9f13-a343-5ef5-a860-96a04606cde8",
+    "name": "TRILOK SINGH CHEEMA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Kashipur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Kashipur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b9f3d7e3-e0ea-5866-bd26-7d6f28d3390c",
+    "name": "ADESH SINGH CHAUHAN",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Jaspur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Jaspur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "58e12460-ec1c-5e6c-9b35-10d06579561b",
+    "name": "DIWAN SINGH BISHT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Ramnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Ramnagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d25c0b48-39c7-53e1-b732-15f8113a24ab",
+    "name": "BANSHIDHAR BHAGAT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Kaladhungi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Kaladhungi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "921b595f-d88d-508f-a5d5-1b61c7d1f6d6",
+    "name": "SUMIT HRIDAYESH",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Haldwani",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Haldwani",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "99f7a40f-6032-5222-82c6-c2891efdda74",
+    "name": "SARITA ARYA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Nainital",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Nainital",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8932dc08-d83d-5c49-ac68-d63095088e2c",
+    "name": "RAM SINGH KAIRA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Bhimtal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Bhimtal",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d6134972-c920-5588-840a-412fd6fbf485",
+    "name": "MOHAN SINGH BISHT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Lalkuwa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Lalkuwa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "83820174-f18d-561f-973c-2276534b1bf7",
+    "name": "KAILASH CHANDRA GAHTORI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Champawat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Champawat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "27bd5aba-b7fd-50cb-8d91-3aad33279c45",
+    "name": "KHUSHAL SINGH ADHIKARI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Lohaghat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Lohaghat",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c671286b-b4bf-5c9c-a944-481b18546dc9",
+    "name": "MOHAN SINGH",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Jageshwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Jageshwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d206ce65-bcfe-58a3-8a5d-ac4e12dc5caf",
+    "name": "MANOJ TEWARI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Almora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Almora",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e20984fe-fc2e-599e-982b-be0099fc3044",
+    "name": "REKHA ARYA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Someshwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Someshwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c84bd727-d9e5-54c7-94dc-0a0882914341",
+    "name": "PRAMOD NAINWAL",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Ranikhet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Ranikhet",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7b2b6a9e-3712-543b-aa00-a186b5eec99f",
+    "name": "MAHESH JEENA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Salt",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Salt",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "768db14d-0cc4-5188-850d-d170d3019d51",
+    "name": "MADAN SINGH BISHT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Dwarahat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Dwarahat",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e7d8aea5-b100-562d-ba03-0ca56e51cfa8",
+    "name": "CHANDAN RAM DAS",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Bageshwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Bageshwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b4c0b537-e5aa-59e5-837e-30047d404147",
+    "name": "SURESH GARIYA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Kapkot",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Kapkot",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3bd7736b-9d17-5e4a-9373-be36b7c998fa",
+    "name": "FAKEER RAM",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Gangolihat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Gangolihat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "71954bd4-4d42-5315-b003-d10ecc0a96ac",
+    "name": "MAYUKH MAHAR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Pithoragarh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Pithoragarh",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c89aa6d6-78fb-56a5-b866-f7220c20c3cd",
+    "name": "VISHAN SINGH",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Didihat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Didihat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "61666091-2964-5c36-8aa5-206c05a6aca3",
+    "name": "HARISH SINGH DHAMI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Dharchula",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Dharchula",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "67f305cd-c66c-5473-a1f2-4a9e70a48d04",
+    "name": "RITU KHANDURI BHUSHAN",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Kotdwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Kotdwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4a4181b9-1548-55f5-ab8d-1cb8dd9cb823",
+    "name": "DILEEP SINGH RAWAT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Lansdowne",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Lansdowne",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6919b073-2c55-5dc3-af28-3db0fc30a66b",
+    "name": "SATPAL MAHARAJ",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Chaubattakhal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Chaubattakhal",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8ccaeecf-b5a3-5ac5-aaaa-de1f1169a227",
+    "name": "DHAN SINGH RAWAT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Srinagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Srinagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b3e29064-71f8-51fd-83ea-74accae7f00e",
+    "name": "RAJKUMAR PORI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Pauri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Pauri",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c42d6fa1-fb83-55be-9f3c-9fa693e80ad9",
+    "name": "RENU BISHT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Yamkeshwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Yamkeshwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1e9591ce-e844-525f-8196-9173c10a3eaa",
+    "name": "ANUPAMA RAWAT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Haridwar Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Haridwar Rural",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b579d50b-18b0-5f26-985f-bc7ed643c520",
+    "name": "SHAHZAD",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Laksar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Laksar",
+          "party": "Bahujan Samaj Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "01d24b91-b443-5a39-94f4-7e9bf42c3f45",
+    "name": "SARWAT KAREEM ANSARI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Manglaur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Manglaur",
+          "party": "Bahujan Samaj Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dd27fc30-f08f-58e8-9054-5251b3cf435c",
+    "name": "UMESH KUMAR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Khanpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Khanpur",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1ed2b95c-972c-5796-9876-4c9924368a2f",
+    "name": "PRADEEP BATRA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Roorkee",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Roorkee",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f7a87c94-63e3-5e70-80f8-8a4c23dd951b",
+    "name": "FURKAN AHMAD",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Piran Kaliyar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Piran Kaliyar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e27a5876-a320-5900-831b-3a89f935dd0e",
+    "name": "VIRENDRA KUMAR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Jhabrera",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Jhabrera",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "aa3daefb-91cb-5318-90e4-245649366125",
+    "name": "MAMATA RAKESH",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Bhagwanpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Bhagwanpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "54cbe3c1-d6d0-5853-a92a-ec00854a6533",
+    "name": "RAVI BAHADUR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Jwalapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Jwalapur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "69555bf3-418f-5efc-8e85-87064fd9b4a0",
+    "name": "ADESH CHAUHAN",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "BHEL Ranipur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "BHEL Ranipur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7effeb61-c7f0-567b-83d8-677321b190bd",
+    "name": "MADAN KAUSHIK",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Haridwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Haridwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6fa64adc-3138-58ad-9f7c-077a15f1a0f8",
+    "name": "PREM CHAND AGGARWAL",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Rishikesh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Rishikesh",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f4309f6d-39f2-5dc2-b21c-2edd11c721cc",
+    "name": "BRIJ BHUSHAN GAIROLA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Doiwala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Doiwala",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5d3a3ea3-02d5-5c84-a5c7-a966593f3f00",
+    "name": "GANESH JOSHI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Mussoorie",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Mussoorie",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fbe184cf-0f21-5867-a69b-c6934ab1b72e",
+    "name": "SAVITA KAPOOR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Dehradun Cantt.",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Dehradun Cantt.",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "04d51712-2445-5ad2-984a-b39a733478ce",
+    "name": "KHAJAN DAS",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Rajpur Road",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Rajpur Road",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "749770cb-3e9e-5011-9cc6-f3d43881608b",
+    "name": "UMESH SHARMA KAU",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Raipur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Raipur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7502599c-e586-5f31-8edc-dbbe3f9fe4f3",
+    "name": "VINOD CHAMOLI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Dharampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Dharampur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6aa443b7-f9c9-5d2e-bfa3-106c9ffe68a0",
+    "name": "SAHDEV SINGH PUNDIR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Sahaspur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Sahaspur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "545831fd-4f41-5ee9-86aa-3cf36a9d5e29",
+    "name": "MUNNA SINGH CHAUHAN",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Vikasnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Vikasnagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4836ee5d-7dae-5e4d-bdb6-2afd3404c99f",
+    "name": "PRITAM SINGH",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Chakrata",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Chakrata",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "273c47a9-1789-576d-afe9-163091c81229",
+    "name": "PRITAM SINGH PANWAR",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Dhanolti",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Dhanolti",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3aa6bfba-1a2e-577f-8bf0-d8ae02cc62ec",
+    "name": "KISHORE UPADHYAY",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Tehri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Tehri",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9aedd961-ebf9-5715-8bcb-0a1a9cf3b8cc",
+    "name": "VIKRAM SINGH NEGI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Pratap Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Pratap Nagar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3527b1b2-a418-5050-9fd5-5bad886e6bc9",
+    "name": "SUBODH UNIYAL",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Narendranagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Narendranagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "29e6ef92-0241-5d02-9315-ddfa7ab07447",
+    "name": "VINOD KANDARI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Devprayag",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Devprayag",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9a00224a-acaf-5acb-9ca5-c0f6e9dcfb10",
+    "name": "SHAKTI LAL SHAH",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Ghansali",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Ghansali",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "35491490-195e-5631-aaa4-8e04d2acadda",
+    "name": "BHARAT SINGH CHAUDHARY",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Rudraprayag",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Rudraprayag",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f2969af3-e69c-5fb9-ad8e-ff09f1999163",
+    "name": "SHAILA RANI RAWAT",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Kedarnath",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Kedarnath",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "be21dad7-c4d3-5fb1-abc5-8327569a362d",
+    "name": "ANIL NAUTIYAL",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Karanprayag",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Karanprayag",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9482f979-f0e4-582c-848b-9ea096e2c20d",
+    "name": "BHUPAL RAM TAMTA",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Tharali",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Tharali",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8606284b-4445-58ab-b787-db965f75d558",
+    "name": "RAJENDRA SINGH BHANDARI",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Badrinath",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Badrinath",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d8492883-3212-5e1e-9717-a7a7585a209c",
+    "name": "SURESH SINGH CHAUHAN",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Gangotri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Gangotri",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "92a50f7d-b625-516a-a081-316200ee7e24",
+    "name": "SANJAY DOBHAL",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Yamunotri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Yamunotri",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "760bd624-09f2-5f6b-8c0c-c1b0b02fc492",
+    "name": "DURGESHWAR LAL",
+    "photo": null,
+    "state": "Uttarakhand",
+    "constituency": "Purola",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Uttarakhand",
+          "constituency": "Purola",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b96dbfda-7e32-5eb2-8b4b-9e8807ae2f5b",
+    "name": "PRADYUMANSINH JADEJA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Abdasa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Abdasa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "41dafa59-dc15-543e-a817-a4cace2a93b5",
+    "name": "ANIRUDDH DAVE",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mandvi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mandvi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5977ee74-1f63-5b40-aa72-922f296ce1ef",
+    "name": "KESHAVLAL PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bhuj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bhuj",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "00284103-2e69-5d97-b2b4-c32dc7402308",
+    "name": "TRIKAMBHAI BIJALBHAI CHHANGA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Anjar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Anjar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cef0a10c-b4d2-568e-a450-c978c2be10a3",
+    "name": "MALTIBEN MAHESHVARI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Gandhidham",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Gandhidham",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "34720b09-bd3d-5a9f-8820-e142250e9a7d",
+    "name": "VIRENDRASINH JADEJA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Rapar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Rapar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "03fbdbf6-b50a-54e9-8ce4-0e1f0a5d13b4",
+    "name": "SWAROOPJI SARDARJI THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vav",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vav",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f881d670-95ae-5426-a1f0-ed39debc5bd6",
+    "name": "SHANKARBHAI CHAUDHARY",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Tharad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Tharad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4b8a3d50-c466-53dc-84ff-f559282e43a9",
+    "name": "MAVJIBHAI MAGANBHAI DESAI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dhanera",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dhanera",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "61bf3118-323c-5b9c-a427-0780063af156",
+    "name": "KANTIBHAI KHARADI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Danta",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Danta",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8a3704cb-da17-534b-948e-e2729cca30d0",
+    "name": "JIGNESH MEVANI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vadgam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vadgam",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "54c8f63b-8a50-52ba-a006-555687d3d349",
+    "name": "ANIKETBHAI THAKAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Palanpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Palanpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2cd4bc7e-e4e7-528f-882f-9eea054df39b",
+    "name": "PRAVEEN MALI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Deesa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Deesa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c71e1b1f-e3fb-5f35-a05a-289eb4ed718d",
+    "name": "KESHAJI CHAUHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Deodar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Deodar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5e4f5ee3-a720-5859-9519-a079e0757324",
+    "name": "AMRUTBHAI MOTIJI THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kankrej",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kankrej",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3de1e614-b18a-5a16-a013-8770856f0d02",
+    "name": "LOVINGJI THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Radhanpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Radhanpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5986c169-cecb-5d6b-a6e2-3e5237215d23",
+    "name": "DINESH THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Chanasma",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Chanasma",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "523a6833-f309-56d9-a915-0a4a7ac7867b",
+    "name": "KIRIT PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Patan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Patan",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "26afe345-7b3c-5a7a-bf03-8ad722ac0287",
+    "name": "BALVANSINH RAJPUT",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Sidhpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Sidhpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "144c6c33-3f6a-541e-9776-64c114cac8bd",
+    "name": "SARDARSINH CHUADHARY",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kheralu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kheralu",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e7be683e-d4c6-58d4-8b83-e968357605ae",
+    "name": "KIRITBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Unjha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Unjha",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "459bf054-1b1a-5ebb-af40-670221f0544c",
+    "name": "RUSHIKESHBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Visnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Visnagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f3030f65-3b8b-50b8-b000-96bd72e4b41b",
+    "name": "SUKHAJI THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bechraji",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bechraji",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "36ad73e7-0768-5240-85bc-20b6c6eb440a",
+    "name": "RAJENDRAKUMAR DANESHWAR CHAVDA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kadi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kadi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "198556f6-69d0-52e2-a67d-6f497547097d",
+    "name": "MUKESH PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mahesana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mahesana",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c67846ad-388c-54a7-bb75-b9d82449601b",
+    "name": "DR. C. J. CHAVDA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vijapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vijapur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f67be7dc-4db6-5d94-8041-98864e157b77",
+    "name": "VD JHALA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Himatnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Himatnagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a374fb80-6e3b-55e5-a72d-275f757ae7ca",
+    "name": "RAMANLAL VORA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Idar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Idar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "61b36cec-e9a7-529d-a103-b1aafbf0a7a8",
+    "name": "TUSHAR CHAUDHARY",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Khedbrahma",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Khedbrahma",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2f4e117c-bb0f-5daa-a1f9-93c4441c8e20",
+    "name": "POONAMCHAND BARANDA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bhiloda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bhiloda",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6196c8ef-a5f4-549c-8dfb-87e653568621",
+    "name": "BHIKHUBHAI PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Modasa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Modasa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "42292b6f-6688-529f-af5d-1e4344dd3c5c",
+    "name": "DHAVALSINH NARENDRASINH ZALA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bayad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bayad",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0c7ceed9-9265-58e1-9297-a6d3c171f303",
+    "name": "GAJENDRASINH PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Prantij",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Prantij",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "171eb079-3f76-52fa-8b8c-2274707f3a45",
+    "name": "BALRAJSINH CHAUHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dahegam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dahegam",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c7c39c73-c21a-5f8a-bdf5-37a9060398ad",
+    "name": "RITABEN THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Gandhinagar North",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Gandhinagar North",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fa6d81d6-2fee-5bb3-aecd-430af17aaeb7",
+    "name": "ALPESH THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Gandhinagar South",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Gandhinagar South",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a4220abc-ef03-5d93-8f1b-20a77d3826f9",
+    "name": "JAYANTIBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mansa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mansa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1a257a8b-c227-5c7e-babb-bf26bbd8dd60",
+    "name": "BAKAJI THAKOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kalol",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kalol",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f1dc5ff6-682f-5ba7-94a0-1c63bba4fe98",
+    "name": "HARDIK PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Viramgam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Viramgam",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0d40c553-55d0-554c-a8ef-31581913ab70",
+    "name": "KANUBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Sanand",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Sanand",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2a520dfe-4dd3-504b-ba15-3fb096cb4670",
+    "name": "BHUPENDRA PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Ghatlodia",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Ghatlodia",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "087bdf41-6bd0-5eac-935e-559142574261",
+    "name": "AMITBHAI THAKAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vejalpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vejalpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5378f415-a02d-5ebd-9a53-c204096ce251",
+    "name": "BABU SINGH JADHAV",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vatva",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vatva",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ae692b07-c9e2-576e-b5ab-7e38fb64fa2e",
+    "name": "AMITBHAI SHAH",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Ellis Bridge",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Ellis Bridge",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "095a005a-549e-50b0-8b90-2196f928621a",
+    "name": "JITENDRABHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Naranpura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Naranpura",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0e98d57c-00fa-5201-9509-676df3db7030",
+    "name": "JAGDISHBHAI VISHVAKARMA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Nikol",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Nikol",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "94b9186b-eba4-5b7f-b639-dfd3338b3632",
+    "name": "DR. PAYALBEN KUKRANI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Naroda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Naroda",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "55bd5083-4aab-5348-957c-b054837cd7f9",
+    "name": "KANCHANBEN RADADIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Thakkarbapa Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Thakkarbapa Nagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c8a3379b-1b25-5f38-8619-7172118c345a",
+    "name": "DINESHSINH KUSHWAH",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bapunagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bapunagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "23a4f644-c6da-5066-97a7-d2bfd5833124",
+    "name": "DR. HASMUKHBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Amraiwadi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Amraiwadi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "344bbd7b-4196-56a1-9831-850345375884",
+    "name": "KAUSHIKBHAI JAIN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dariapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dariapur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fd339974-09b6-5ba0-be12-ae65463d3e8d",
+    "name": "IMRAN KHEDAVALA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jamalpur-Khadia",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jamalpur-Khadia",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a04a9af2-2bec-5c59-86f5-1f102e381091",
+    "name": "AMULBHAI BHATT",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Maninagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Maninagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "11c3bf03-db77-5ee1-9904-e9cbd43822b9",
+    "name": "SHAILESH PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Danilimda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Danilimda",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7930b82f-ce97-52fa-a046-2ba6604fb005",
+    "name": "DR. HARSHADBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Sabarmati",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Sabarmati",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6c1a9048-2c5a-5a3c-8af6-533e7d86b327",
+    "name": "DARSHNABEN VAGHELA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Asarwa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Asarwa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c0150f7d-2216-54a6-9aae-cfafef57faf1",
+    "name": "BABUBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Daskroi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Daskroi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bba314f5-a83f-5055-9561-14cf827deb91",
+    "name": "KIRITSINH DABHI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dholka",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dholka",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4f3348af-01c1-5875-a4c1-fb1ffdce1a55",
+    "name": "KALUBHAI DABHI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dhandhuka",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dhandhuka",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b7495af3-9622-5964-bd40-65c7072d008d",
+    "name": "PARSHOTTAMBHAI PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dasada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dasada",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1c0b856d-61cc-53b5-8ac1-299b92eab692",
+    "name": "KIRITSINH RANA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Limbdi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Limbdi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "822504ad-4f7c-5cc0-8ae9-965623b3a75c",
+    "name": "JAGDISHBHAI MAKWANA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Wadhwan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Wadhwan",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "85073c9c-a2b8-5db2-afbe-2cf4a03a8ef7",
+    "name": "SHAMJIBHAI CHAUHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Chotila",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Chotila",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "921146a2-4785-5ed8-8d5c-9871292c8d34",
+    "name": "PRAKASHBHAI VARMORA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dhrangadhra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dhrangadhra",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c6941a5d-54a6-532f-96b5-2354f5b2175a",
+    "name": "KANTILAL ARUTIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Morbi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Morbi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "34d68ca5-57b7-57b0-89e0-a81c5db0efa4",
+    "name": "DURLABHJIBHAI DETHARIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Tankara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Tankara",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "be6cd396-0529-57b8-81d0-c9ff897a2fdb",
+    "name": "JITENDRABHAI SOMANI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Wankaner",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Wankaner",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4cc62e50-94d1-53a2-b030-7bdc68ac5dd4",
+    "name": "UDAYKUMAR KANGAD",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Rajkot East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Rajkot East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "61c90776-4886-5301-b296-341ba10637ea",
+    "name": "DR. DARSHITA SHAH",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Rajkot West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Rajkot West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a8084adf-99d4-5331-af0b-7168f7593714",
+    "name": "RAMESHBHAI TILARA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Rajkot South",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Rajkot South",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e667673b-b265-5f8e-b19c-fe51c82af7c9",
+    "name": "BHANUBEN BABARIA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Rajkot Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Rajkot Rural",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1c68a4e6-12d0-548f-9e95-da920baedf0a",
+    "name": "KUNWARJIBHAI BAVALIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jasdan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jasdan",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "440659df-8c2e-5a87-bafb-7a27db2bf106",
+    "name": "GITABA JADEJA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Gondal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Gondal",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3b73ef46-b59c-535c-865d-e46938b95bbb",
+    "name": "JAYESHBHAI RADADIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jetpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jetpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a1c7349d-a50a-5fd4-b018-a3ae3f76934a",
+    "name": "MAHENDRABHAI PADALIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dhoraji",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dhoraji",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "547dc9b2-75cf-527f-b860-45898f3e3d41",
+    "name": "MEGHJIBHAI CHAVDA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kalavad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kalavad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ffbd00e4-92dc-5f5f-8647-de02fecb8e7e",
+    "name": "RAGHAVJIBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jamnagar Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jamnagar Rural",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9ea266c4-316c-53ab-a4cd-4b0a5bf9a9bd",
+    "name": "RIVABA JADEJA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jamnagar North",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jamnagar North",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f7ffd857-a8f6-555d-90ad-ddccfaab88ba",
+    "name": "DIVYESHBHAI AKBARI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jamnagar South",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jamnagar South",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "30efe81d-bfc3-53b7-ab9d-11d4562714b3",
+    "name": "HEMANT KHAVA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jamjodhpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jamjodhpur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "34519d9f-4784-513e-b23d-b5ac8dd22254",
+    "name": "MULUBHAI BERA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Khambhalia",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Khambhalia",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4413fb82-ab4b-5af3-b2a5-d4d3fab72b82",
+    "name": "PABUBHA MANEK",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dwarka",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dwarka",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "93753a8f-d777-5784-af83-0ff6dcf09f31",
+    "name": "ARJUN DEVABHAI MODHWADIA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Porbandar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Porbandar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a58ddf6a-906e-53c3-b4b1-920a1315bc07",
+    "name": "KANDHALBHAI SARMANBHAI JADEJA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kutiyana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kutiyana",
+          "party": "Samajwadi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c053d3bb-ad19-59a3-9c6c-e8cdc62014b1",
+    "name": "ARVINDBHAI JINABHAI LADANI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Manavadar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Manavadar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0c2c1131-ff6a-5cea-b767-07bddfc012ea",
+    "name": "SANJAYBHAI KORADIA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Junagadh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Junagadh",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fae8cbb7-1504-5597-963f-68a796ca796d",
+    "name": "GOPAL ITALIA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Visavadar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Visavadar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2928ab01-94d7-5c5d-ab13-a07df8d9f677",
+    "name": "DEVABHAI MALAM",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Keshod",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Keshod",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e8e6f306-b430-5b05-b992-14ebfae1c873",
+    "name": "BHAGWANJIBHAI KARGATHIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mangrol",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mangrol",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "251c3c39-472b-5869-8fdf-ba547d26e819",
+    "name": "VIMAL CHUDASMA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Somnath",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Somnath",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "10bb7f72-8de7-5cba-8f0e-dea9e1c633ff",
+    "name": "BHAGWANBHAI BARAD",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Talala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Talala",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1b27ead9-27b7-5b99-9aff-e34aa4cd45db",
+    "name": "DR.PRADYUMAN VAJA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kodinar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kodinar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "af521976-1352-5e39-bc24-37324c30a482",
+    "name": "KALUBHAI RATHOD",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Una",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Una",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb75c1dc-b473-51f2-8bdf-6702cd73795e",
+    "name": "JAYSUKHBHAI KAKDIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dhari",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dhari",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "83d902bb-3bae-5939-b89a-b98cd5842f1b",
+    "name": "KUSHIKBHAI VEKARIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Amreli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Amreli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "32599831-9b7c-5975-baeb-dab99d93c7d9",
+    "name": "JANAKBHAI TALAVIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Lathi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Lathi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "22097b96-20c6-5f5d-8b1e-e60cf7363525",
+    "name": "MAHESH KASHWALA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Savarkundla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Savarkundla",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7acbb2ba-c6cb-5851-9c82-249ea4975b52",
+    "name": "HIRABHAI SOLANKI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Rajula",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Rajula",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f6c3ffe8-8234-59ca-bc1b-621514d77079",
+    "name": "SHIVABHAI GOHIL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mahuva",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mahuva",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "674d6b92-f7c1-56fa-9e9f-8ff9297ece0c",
+    "name": "GAUTAMBHAI CHAUHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Talaja",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Talaja",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb59efd3-5b4c-5f39-8576-35e947e57d27",
+    "name": "SUDHIR VAGHANI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Gariadhar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Gariadhar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3606dcde-9406-59ba-9df9-be42dbfaf4f5",
+    "name": "BHIKHABHAI BARAIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Palitana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Palitana",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0caf0078-efbe-5f2d-b44f-8674aa804afc",
+    "name": "PARSHOTTAMBHAI SOLANKI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bhavnagar Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bhavnagar Rural",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b5eb0a2b-d0e1-5267-ab08-45374db03cfa",
+    "name": "SEJAL RAJIV KUMAR PANDYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bhavnagar East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bhavnagar East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dd4f9ca7-962c-5583-bab9-8e284d667040",
+    "name": "JITENDRA VAGHANI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bhavnagar West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bhavnagar West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8202dabe-14ec-5e30-97a7-934b2163a6da",
+    "name": "SHAMBHUPRASADJI TUNDIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Gadhada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Gadhada",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "60e2041c-a69c-5dc8-b993-daa234c51a5f",
+    "name": "UMESH MAKWANA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Botad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Botad",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e805fef2-9d93-5a36-aca0-d051ae40de11",
+    "name": "CHIRAGKUMAR ARVINDBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Khambhat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Khambhat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5ff7b4d5-7ce8-5ad4-883a-09315108ce9c",
+    "name": "RAMANBHAI SOLANKI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Borsad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Borsad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fed67017-78ad-5f6b-82bd-4ac2aa34ff81",
+    "name": "AMIT CHAVDA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Anklav",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Anklav",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "94105e07-4cd0-57d8-a0ad-a62e5a76a234",
+    "name": "GOVINDBHAI PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Umreth",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Umreth",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6c8df49b-59ac-5af9-921e-93341468dbba",
+    "name": "YOGESHBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Anand",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Anand",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c4b7f597-dd33-57c3-a431-98ae3ba03d62",
+    "name": "KAMLESH PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Petlad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Petlad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3624ffb1-141e-57b4-afb6-07fe0c1b74ff",
+    "name": "VIPULBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Sojitra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Sojitra",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8024929b-68d9-5ed2-a147-a114c0ac335f",
+    "name": "KALPESHBHAI PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Matar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Matar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "98987cbe-365a-516b-badf-4be4a8f45308",
+    "name": "PANKAJBHAI DESAI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Nadiad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Nadiad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b4018544-e710-5f82-a85c-644bdd7cca69",
+    "name": "ARJUNSINH CHAUHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mehmedabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mehmedabad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eb0e016a-e324-538c-a863-ec2b2fe1807b",
+    "name": "SANJAYSINH MAHIDA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mahudha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mahudha",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f892e093-d041-50ff-aa70-65daadd24135",
+    "name": "YOGENDRASINH PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Thasra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Thasra",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "317573eb-21f4-5b74-ab0e-69aed6f4cc1a",
+    "name": "RAJESHKUMAR ZALA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kapadvanj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kapadvanj",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0bf8ba40-0af8-5d20-af03-fc06c06073f7",
+    "name": "MANSINH CHAUHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Balasinor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Balasinor",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ce9816a8-e631-5040-b19d-eca9551318dc",
+    "name": "GULAB SINGH",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Lunavada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Lunavada",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bad1ab66-8679-57d6-922b-eaeb0deeeeda",
+    "name": "KUBERBHAI DINDOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Santrampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Santrampur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7e9eb6e6-029c-568b-af0a-09b7872dea4b",
+    "name": "JETHABHAI AHIR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Shehra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Shehra",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "013e069b-8963-56ce-a97e-fceff4a904a8",
+    "name": "NIMISHABEN SUTHAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Morva Hadaf",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Morva Hadaf",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bf86879d-2e80-5799-92eb-00feac1b24a6",
+    "name": "CHANDRASINH RAULJI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Godhara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Godhara",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "828b813c-2ded-5cdb-9b97-f7400cbc63db",
+    "name": "FATESINH CHAUHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kalol",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kalol",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a4c1a9f4-dc40-590c-8583-97513abec703",
+    "name": "JAYDRATHSINHJI PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Halol",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Halol",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "48840914-f755-5c2d-9415-d615f81d2488",
+    "name": "RAMESHBHAI KATARA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Fatepura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Fatepura",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3376247b-f9b3-5dde-af4f-0329188b6654",
+    "name": "MAHESH BHURIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jhalod",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jhalod",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "273ffb96-31c8-5ee5-865d-1d0e0bf19eed",
+    "name": "SHAILESHBHAI BHABHOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Limkheda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Limkheda",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "837026bc-9368-5082-a171-91da00a617b1",
+    "name": "KANAIYALAL KISHORI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dahod",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dahod",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f33dbc41-ee5a-5e35-bad5-264034316dbf",
+    "name": "MAHENDRABHAI BHABHOR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Garbada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Garbada",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c3e45cc0-7c3e-5d48-bac6-4b60e560c391",
+    "name": "BACHUBHAI KHABAD",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Devgadh Baria",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Devgadh Baria",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e3589caf-66ae-5da6-81fa-287dfad3a04c",
+    "name": "KETANBHAI INAMDAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Savli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Savli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "599c5ea6-2fc4-5464-9209-c0c4fa0c9ecd",
+    "name": "DHARMENDRASINH VAGHELA (BAPU)",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vaghodia",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vaghodia",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a52a6a0b-84c4-5780-9e17-d7794cd3392a",
+    "name": "RAJENDRASINH RATHVA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Chhota Udaipur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Chhota Udaipur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a2493e49-4796-5e0e-b1f2-7697d10264c7",
+    "name": "JAYANTIBHAI RATHWA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jetpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jetpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb3efe08-c9a4-5995-bbc9-5cc799a8d15f",
+    "name": "ABHESINH TADVI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Sankheda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Sankheda",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0aa9e18c-d2ff-5dfc-8cb8-dfe2c447ca31",
+    "name": "SHAILESHBHAI MEHTA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dabhoi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dabhoi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "638aa71b-6183-50b5-b706-da2757f3aa3d",
+    "name": "MANISHABEN VAKIL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vadodara City",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vadodara City",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb56740e-b0af-5c48-b2ec-97913bfa9a9d",
+    "name": "KEYUR ROKADIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Sayajiganj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Sayajiganj",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c0ee5c75-a76e-514b-879a-e54253e30ca5",
+    "name": "CHAITANYA DESAI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Akota",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Akota",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "82976194-e97c-50a5-b2d2-fc61ea9e0303",
+    "name": "BALKRISHNA SHUKLA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Raopura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Raopura",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b244cf34-cc2e-5096-98a1-be1bee69bada",
+    "name": "YOGESHBHAI NARANDAS PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Manjalpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Manjalpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2fcb85f3-5ec6-5f52-aeb3-1bf0eb665387",
+    "name": "CHAITANYASINH ZALA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Padra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Padra",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3fe8619e-defc-504e-b303-62206657c510",
+    "name": "AKSHAYKUMAR PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Karjan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Karjan",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "053833df-936c-5182-92f6-872c9fca1f83",
+    "name": "DR. DARSHNABEN DESHMUKH",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Nandod",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Nandod",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5e5d0b92-a460-5b09-8ebd-49017cbcb3d2",
+    "name": "CHAITAR VASAVA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dediapada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dediapada",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f2235e58-a44b-580c-828e-599a8e9d6b72",
+    "name": "DEVKISHORDASJI SADHU",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jambusar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jambusar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "96bbcb28-867b-5a9f-9826-80a99f41b764",
+    "name": "ARUNSINH RANA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vagra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vagra",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a297255c-8e32-58da-bad7-d80408c6627f",
+    "name": "RITESHBHAI VASAVA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jhagadiya",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jhagadiya",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "87e4347c-72f3-57d4-97a9-ac3c724a3023",
+    "name": "RAMESHBHAI MISTRI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bharuch",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bharuch",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9bd9b96d-9462-52ef-85e0-39da4f3b677f",
+    "name": "ISHWARSINH PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Ankleshwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Ankleshwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6ec497fd-e88f-55ec-ae7e-f3db42ed3d60",
+    "name": "MUKESHBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Olpad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Olpad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6f26602e-e0b1-5844-b38d-4ee4b7284ac3",
+    "name": "GANPATBHAI VASABA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mangrol(ST",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mangrol(ST",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "20a18c64-4a84-59d7-85e4-33b288a9d23f",
+    "name": "KUNVARJIBHAI HALPATI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mandvi(ST",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mandvi(ST",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ce1776ee-de40-564a-aef5-7c293b150044",
+    "name": "PRAFULBHAI PANSERIA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kamrej",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kamrej",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "863ddc60-921e-5b8d-9a03-5ec80bc4b010",
+    "name": "ARVINDBHAI RANA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Surat City East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Surat City East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7fc219e8-0a2a-5ee0-bef9-79623813a3ae",
+    "name": "KANTIBHAI BALLAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Surat City North",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Surat City North",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e1ced1af-cf99-5b4d-83dc-3bad9e69b5ea",
+    "name": "KISHORBHAI KANANI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Varachha Road",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Varachha Road",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b6b0103d-6f51-56f9-b550-aee7ac9c4a34",
+    "name": "PRAVINBHAI GHOGHARI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Karanj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Karanj",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ba8d7c29-808c-5dc1-8286-0be06135589c",
+    "name": "SANGITABEN PATIL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Limbayat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Limbayat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "98ad9c6d-9ef2-5587-81b2-9d9368591824",
+    "name": "MANUBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Udhna",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Udhna",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d8b718cc-f5cf-5a8e-8772-43b5b7bcb500",
+    "name": "HARSH SANGHVI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Majura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Majura",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "85f49d0f-d4d2-506d-a095-0e5bd55f4b64",
+    "name": "VINODBHAI MORDIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Katargam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Katargam",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3409aa31-88d4-505d-ac87-bb73a03b220c",
+    "name": "PURNESHBHAI MODI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Surat City West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Surat City West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c908e37f-8915-5681-a768-9a1455e6f70b",
+    "name": "SANDEEP DESAI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Choryasi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Choryasi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b53475af-12ec-5341-be98-ec9de7046d1d",
+    "name": "ISHWARBHAI PARMAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Bardoli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Bardoli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cdb4084f-a443-5a1d-aac5-19752b72af51",
+    "name": "MOHANBHAI DHODIYA",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Mahuva",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Mahuva",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "81e8ad74-19eb-5086-952b-f1e5c8045cf3",
+    "name": "MOHANBHAI KOKNI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vyara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vyara",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "91d7ccd4-63a6-5983-a2fa-b1134dea1978",
+    "name": "DR. JAYRAMBHAI GAMIT",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Nizar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Nizar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "82ce3c9d-235a-5a14-8aba-fd4d26f1d646",
+    "name": "VIJAYBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dangs",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dangs",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "93500bd2-ac26-57a7-9e78-7ffcfa8eba9e",
+    "name": "RAMESHBAHI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Jalalpore",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Jalalpore",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d97b0021-7f67-51c4-a9f3-196a24bb7f58",
+    "name": "RAKESH DESAI",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Navsari",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Navsari",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a6b693f6-4385-5ee3-a423-ee227a0ecbc3",
+    "name": "NARESHBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Gandevi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Gandevi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2574b2ea-d3c9-5a15-9299-cbb35913ebb5",
+    "name": "ANANTKUMAR HASMUKHBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Vansda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Vansda",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "253199c3-d1e9-5626-9fd4-1a608247d5fa",
+    "name": "ARVINDBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Dharampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Dharampur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "58724634-b3b6-5bc6-9ad2-01210f9d73e9",
+    "name": "BHARATBHAI PATEL",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Valsad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Valsad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5d8a736d-9ffd-580c-bc1e-ff909da99ba1",
+    "name": "KANUBHAI MOHAN",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Pardi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Pardi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5a90a341-c9a7-58a1-94b8-e9088016d4e9",
+    "name": "JITUBHAI CHAUDHRY",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Kaprada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Kaprada",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4c2d030d-6159-50d7-a16a-ed2bb00e8f1f",
+    "name": "RAMANLAL PATKAR",
+    "photo": null,
+    "state": "Gujarat",
+    "constituency": "Umbergaon",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Gujarat",
+          "constituency": "Umbergaon",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8ccc3d30-eabd-5b58-8ebe-e1391a852ad4",
+    "name": "HANS RAJ",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Churah",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Churah",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bf100743-b4e3-5a85-ab31-0b28c63f3ebb",
+    "name": "DR. JANAK RAJ",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Bharmour",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Bharmour",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ae27f1f3-272f-5713-af88-c4d8215c02b8",
+    "name": "NEERAJ NAYYAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Chamba",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Chamba",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "551fa967-5444-500a-932a-2d3254f0cd4a",
+    "name": "D S THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Dalhousie",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Dalhousie",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f3f34944-8693-5c10-894d-81a17a7331ca",
+    "name": "KULDEEP SINGH PATHANIA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Bhattiyat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Bhattiyat",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "97bf2645-6a01-5838-bf6d-3f25c8fc71c2",
+    "name": "RANVEER SINGH NIKKA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Nurpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Nurpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fb44313f-34a9-549c-8639-96c1d42745a0",
+    "name": "MALENDAR RAJAN",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Indora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Indora",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e9599357-f790-5b57-87dd-2b64606ae8d8",
+    "name": "BHAWANI SINGH PATHANIA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Fatehpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Fatehpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3ee67b3f-bd5d-5a40-891d-83bbeef0577e",
+    "name": "CHANDER KUMAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Jawali",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Jawali",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "48fdf146-6e35-5166-8a92-3203bc06ac8e",
+    "name": "KAMLESH THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Dehra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Dehra",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3f14b902-5c18-5a42-9366-919ffea55cf9",
+    "name": "BIKRAM THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Jaswan Pragpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Jaswan Pragpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cfcc5bf3-7ed0-5dfe-b31b-4db7d6a73fef",
+    "name": "SANJAY RATTAN",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Jawalamukhi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Jawalamukhi",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f56ca075-4caa-50ce-a561-cedcf1fad497",
+    "name": "YADVINDER GOMA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Jaisinghpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Jaisinghpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ee4787e7-9731-5e8e-9134-66599d935020",
+    "name": "VIPIN SINGH PARMAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Sullah",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Sullah",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7d8296d8-39d7-581c-a7f7-c1d8ac68b8b7",
+    "name": "RAGHUBIR SINGH BALI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Nagrota",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Nagrota",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d9faa9e0-52bd-5b56-baf4-31ca554f823c",
+    "name": "PAWAN KAJAL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Kangra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Kangra",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d4c943a5-3bf5-57e7-9cc2-4ad2cbe97f7a",
+    "name": "KEWAL SINGH PATHANIA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Shahpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Shahpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f997caa5-f602-50e5-83f9-3a68c798f70e",
+    "name": "SUDHIR SHARMA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Dharamshala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Dharamshala",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fab74df6-9aac-53fd-b9fc-b74c065af090",
+    "name": "ASHISH BUTAIL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Palampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Palampur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "712cacd8-2fd5-5180-bcb2-253a7caf24c9",
+    "name": "KISHORI LAL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Baijnath",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Baijnath",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "67408dbe-76d9-5961-b920-1a36f23e1a19",
+    "name": "ANURADHA RANA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Lahaul & Spiti",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Lahaul & Spiti",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c715bf2d-cc50-542f-bb98-e7ef2a6eff54",
+    "name": "BHUVNESHWAR GAUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Manali",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Manali",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "46bdcfec-4931-5ccf-8bd0-8d77cef241d6",
+    "name": "SUNDER THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Kullu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Kullu",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "570024fa-e4be-50da-bfae-68a00c3cdc7d",
+    "name": "SURENDRA SHOURIE",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Banjar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Banjar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5959e599-e7c2-5c5d-ba48-06e9d7ecdd91",
+    "name": "LOKENDRA KUMAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Anni",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Anni",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "891c793d-c6b0-5040-9c45-0c3634a5c0bb",
+    "name": "DEEPRAJ KAPOOR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Karsog",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Karsog",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5f3ade6f-0ffd-5c4e-bf46-b12e266e2fef",
+    "name": "RAKESH JAMWAL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Sundernagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Sundernagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d32b369b-e61e-5a92-892a-4fb0819700ac",
+    "name": "VINOD KUMAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Nachan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Nachan",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "44ebe838-a369-5fca-a4b2-1c00857d3e93",
+    "name": "JAI RAM THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Seraj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Seraj",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e602aa29-3760-5379-acb1-05ff092ef751",
+    "name": "POORAN CHAND THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Darang",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Darang",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1870b71d-6733-5347-8c07-17aaf3bc793d",
+    "name": "PRAKASH RANA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Joginder Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Joginder Nagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ba925155-df21-5e04-88e7-47c00eb0e63a",
+    "name": "CHANDERSHEKHAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Dharampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Dharampur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "576535cc-0901-5bfe-9ddf-6db3b82b191d",
+    "name": "ANIL SHARMA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Mandi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Mandi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5d5040de-3d27-5019-9839-723a505f1941",
+    "name": "INDRA SINGH GANDHI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Balh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Balh",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "57c625df-de27-5469-87bc-9eb886337190",
+    "name": "DALEEP THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Sarkaghat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Sarkaghat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7deb49e8-efc0-51ea-9a1f-1a94eccde4c7",
+    "name": "SURESH KUMAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Bhoranj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Bhoranj",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "58955793-d012-5651-b3ae-344ead669f62",
+    "name": "CAPTAIN RANJIT SINGH",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Sujanpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Sujanpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eacabbce-3942-5d9c-bce2-12f65bc79e6b",
+    "name": "ASHISH SHARMA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Hamirpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Hamirpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dd37f257-8697-5510-be4a-518cb35bb308",
+    "name": "INDER DUTT LAKHANPAL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Barsar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Barsar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3552d5c4-6266-524a-b1f8-f93cab77093a",
+    "name": "SUKHWIDER SINGH SUKHU",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Nadaun",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Nadaun",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7b327f7f-c8a9-5740-acd6-cea3f73f1e64",
+    "name": "SUDARSHAN SINGH BABLOO",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Chintpurni",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Chintpurni",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "28921381-a6bc-52ac-9461-eb379caa86ce",
+    "name": "RAKESH KALIA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Gagret",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Gagret",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2642b62a-c597-5795-96ca-31e73d458b00",
+    "name": "MUKESH AGNIHOTRI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Haroli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Haroli",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "82a8f3e7-a737-5be4-8fd7-c5a9aac6fa02",
+    "name": "SATPAL SINGH SATTI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Una",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Una",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "69551784-b010-574a-853f-d07024d30a66",
+    "name": "VIVEK SHARMA (VICKU)",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Kutlehar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Kutlehar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a54ebb09-06ae-5685-a5e2-e0df6fa20cd9",
+    "name": "J R KATWAL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Jhanduta",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Jhanduta",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "71ab5679-9ccc-5cf9-8277-15ff60654596",
+    "name": "RAJESH DHARMANI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Ghumarwin",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Ghumarwin",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "690dc0b9-1ac0-55e6-bf03-53b188d7a44e",
+    "name": "TRILOK JAMWAL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Bilaspur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Bilaspur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4828b0eb-f7cf-5241-9e8a-e9f6911f5d64",
+    "name": "RANDHIR SHARMA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Sri Naina Deviji",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Sri Naina Deviji",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4964849b-e8cf-530c-bda6-e1c1255f69b6",
+    "name": "SANJAY AWASTHI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Arki",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Arki",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8a23f872-79c9-508c-a6c6-11aa1c020ba1",
+    "name": "HARDEEP SINGH BAWA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Nalagarh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Nalagarh",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "531abd30-6491-5348-a30c-811c8387bac6",
+    "name": "RAM KUMAR CHAUDHARY",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Doon",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Doon",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b7593a71-720e-56e8-8ef9-d1977ecfe36e",
+    "name": "DHANI RAM SHANDIL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Solan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Solan",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ee86edf4-3a0e-5145-b92c-90bfc8ab1645",
+    "name": "VINOD SULTANPURI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Kasauli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Kasauli",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "06d86d76-4971-58a7-8056-dbbbf0b556ef",
+    "name": "REENA KASHYAP",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Pachhad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Pachhad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "28e56f9e-30f6-5440-bfb5-13f164c8e790",
+    "name": "AJAY SOLANKI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Nahan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Nahan",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3a60743f-41d6-5626-b369-cd48900dc8a4",
+    "name": "VINAY KUMAR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Sri Renukaji",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Sri Renukaji",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "419597f2-fb2b-5e92-aaa3-b04e589d4cfa",
+    "name": "SUKHRAM CHAUDHARY",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Paonta Sahib",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Paonta Sahib",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b197e60d-1fd9-58d9-90d4-d676642264ff",
+    "name": "HARSHWARDHAN SINGH CHAUHAN",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Shillai",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Shillai",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a11ebaf4-1df5-579f-b88d-2677299c5712",
+    "name": "BALBIR VERMA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Chopal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Chopal",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "168de187-97ee-57bc-a9fb-a8ab2a616c6f",
+    "name": "KULDEEP SINGH RATHORE",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Theog",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Theog",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "11d1105b-04ea-5162-bcbb-1e20bc453b81",
+    "name": "ANIRUDH SINGH",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Kasumpti",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Kasumpti",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dfbcf5ac-f8e3-5053-895a-f44ce9655f2f",
+    "name": "HARISH JANARTHA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Shimla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Shimla",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2953c150-a6d2-5794-b568-75ec70d2fd04",
+    "name": "VIKRAMADITYA SINGH",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Shimla Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Shimla Rural",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fa640a7f-ad84-5322-9b87-56e342270da9",
+    "name": "ROHIT THAKUR",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Jubbal Kotkhai",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Jubbal Kotkhai",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "302e38fb-11d3-5b64-bb23-cb745c95a989",
+    "name": "NAND LAL",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Rampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Rampur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5257ea28-74dd-5a30-998e-f354a7c93488",
+    "name": "MOHAN LAL BRAKTA",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Rohru",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Rohru",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "740b3dbc-7fa8-5ce2-a145-0ab389aaad1a",
+    "name": "JAGAT SINGH NEGI",
+    "photo": null,
+    "state": "Himachal Pradesh",
+    "constituency": "Kinnaur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Himachal Pradesh",
+          "constituency": "Kinnaur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "29d84eb1-1070-55cd-9ce2-0c8be2299bc5",
+    "name": "M.T. RAJA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Rajmahal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Rajmahal",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4771516c-7d7e-56fe-bb25-d8eb5f4f1473",
+    "name": "DHANANJAY SOREN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Borio",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Borio",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9a24c370-ef38-5d64-a7e8-6184a3bfd006",
+    "name": "HEMANT SOREN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Barhait",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Barhait",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "322c7864-f138-5fb8-8064-cd767e8294cb",
+    "name": "HEMLAL MURMU",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Litipara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Litipara",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a65aa3ca-d84f-5dbc-9c55-9552f14ba119",
+    "name": "NISHANT ALAM",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Pakur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Pakur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7c20b3b2-496e-5470-ab40-5d572f987f55",
+    "name": "STEPHEN MARANDI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Maheshpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Maheshpur",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3a903004-5663-5ab8-884a-d3cdd2df0274",
+    "name": "ALOK SOREN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Sikaripara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Sikaripara",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1f4bf882-4f5a-578b-b572-3d58d65a17ef",
+    "name": "RAVINDRANATH MAHTO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Nala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Nala",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3372cf7a-ae5c-5bc6-a825-b3088ccb839e",
+    "name": "IRFAN ANSARI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jamtara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jamtara",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "92ac0b16-04fe-53ef-b2d1-32216f8d9a9c",
+    "name": "BASANT SOREN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Dumka",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Dumka",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "033df81a-a238-5ca0-869e-510ffe67d270",
+    "name": "LOIS MARANDI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jama",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jama",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6ef86f9d-f635-51e2-9fa0-f12c1171b5ef",
+    "name": "DEVENDRA KUNWAR",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jarmundi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jarmundi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "53282592-dad8-50de-8f1d-9adfcd914155",
+    "name": "HAFIZUL HASAN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Madhupur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Madhupur",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "01525510-8068-51e7-a72e-39f486e33e4f",
+    "name": "UDAY SHANKAR SINGH",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Sarath",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Sarath",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fe315ac2-91df-50a4-a6eb-a29124d88290",
+    "name": "SURESH PASWAN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Deoghar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Deoghar",
+          "party": "Rashtriya Janata Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "73a3f82e-3e84-565d-a9d2-27088487cb06",
+    "name": "PRADEEP YADAV",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Poreyahat",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Poreyahat",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d7efdc65-6167-5b5f-9ed7-9fa1c29fee5a",
+    "name": "SANJAY PRASAD YADAV",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Godda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Godda",
+          "party": "Rashtriya Janata Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "153d7aa0-a3f9-5ccf-9c06-d34045a38c4b",
+    "name": "DEEPIKA PANDEY SINGH",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Mahagama",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Mahagama",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9c81f3bc-c3f9-5934-9e7e-3412f84262a6",
+    "name": "DR. NEERA YADAV",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Kodarma",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Kodarma",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fd8af7ec-3b0f-566d-87f3-60d35110db2d",
+    "name": "AMIT KUMAR YADAV",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Barkatha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Barkatha",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "400286fe-d751-5116-99be-cc48c38496e6",
+    "name": "MANOJ YADAV",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Barhi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Barhi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7e923ffe-ec8a-52e2-a3e3-4974bc23af24",
+    "name": "ROSHAN LAL CHAUDHARY",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Barkagaon",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Barkagaon",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9d841270-ff75-5cd8-9ba1-fce7068b59b0",
+    "name": "MAMTA DEVI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Ramgarh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Ramgarh",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2b39b41d-050a-5b37-971f-f43bf4777613",
+    "name": "NIRMAL MAHTO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Mandu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Mandu",
+          "party": "All Jharkhand Students Union Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8527b9e5-8578-52f3-9111-c30d26785cf3",
+    "name": "PRADEEP PRASAD",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Hazaribagh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Hazaribagh",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c433a4e9-b664-5791-accb-e3d44488cd1e",
+    "name": "UJJWAL DAS",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Simaria",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Simaria",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a3146962-c748-52d2-825a-787d81301660",
+    "name": "JANARDHAN PASWAN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Chatra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Chatra",
+          "party": "Lok Janshakti Party (Ram Vilas)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d5128654-189b-55e3-9a57-a55fbd223504",
+    "name": "BABULAL MARANDI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Dhanwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Dhanwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ad6614d0-6690-5d77-9ef8-a0e27f5fdec6",
+    "name": "NAGENDRA MAHTO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Bagodar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Bagodar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0aa2d4f0-7415-543f-b384-5c278e4aa70b",
+    "name": "DR. MANJU DEVI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jamua",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jamua",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "de794b52-8edf-54fd-9e70-5fe6b4a22e2e",
+    "name": "KALPANA MURMU SOREN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Gandey",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Gandey",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ffa11cf6-8aae-57ba-895a-b61d51de1c80",
+    "name": "SUDIWAY KUMAR",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Giridih",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Giridih",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "63ccaee8-be2d-5dd3-8883-262cae8f4c96",
+    "name": "JAIRAM KUMAR MAHATO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Dumri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Dumri",
+          "party": "Jharkhand Loktantrik Krantikari Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9f68222c-2415-5d22-af7c-3de247a6dd24",
+    "name": "YOGENDRA PRASAD",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Gomia",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Gomia",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ab63ad03-e39a-5716-a594-0a004e9d55d1",
+    "name": "KUMAR JAI MANGAL",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Bermo",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Bermo",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e304321f-63e3-5f5e-8744-09ad0eaab404",
+    "name": "SHWETA SINGH",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Bokaro",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Bokaro",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1575815c-7b67-5ac9-a208-47eda7a16f5c",
+    "name": "UMAKANT RAJAK",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Chandankyari",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Chandankyari",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c87be10c-8f29-54ae-ad32-2aabe6994b37",
+    "name": "CHANDRADEO MAHATO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Sindri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Sindri",
+          "party": "Communist Party of India (Marxist-Leninist) Liberation",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9d4518b0-adeb-57ba-8890-29c95615d155",
+    "name": "ARUP CHATTERJEE",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Nirsa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Nirsa",
+          "party": "Communist Party of India (Marxist-Leninist) Liberation",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "baafa1df-c04e-51f8-8e5a-238b88a0ef4b",
+    "name": "RAJ SINHA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Dhanbad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Dhanbad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "afaf8b51-0a5e-5aa9-b590-41c784cfd4e4",
+    "name": "RAGINI SINGH",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jharia",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jharia",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ac53d2ae-7e8e-545b-a882-ee98b21042a5",
+    "name": "MATHURA MAHATO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Tundi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Tundi",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "83d77903-0322-51fe-81c9-692d074ffe4c",
+    "name": "SHATRUGHAN MAHTO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Baghmara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Baghmara",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "791e2f65-ec17-5b97-9d29-ff5696f9de4f",
+    "name": "SAMIR MOHANTY",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Baharagora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Baharagora",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a8ac190e-b43b-5a54-939f-69b204c86250",
+    "name": "SOMESH CHANDRA SOREN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Ghatsila",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Ghatsila",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cf73da8d-610b-5400-a393-cc06d7656b47",
+    "name": "SANJIB SARDAR",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Potka",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Potka",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "330b68d6-ed23-5773-8d3f-521815f61573",
+    "name": "MANGAL KALINDI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jugsalai",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jugsalai",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fa9068a5-6da0-5e90-b68e-c0ef9332103c",
+    "name": "PURNIMA DAS SAHU",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jamshedpur East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jamshedpur East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "99b31d73-3ce3-5124-990b-60b662da1042",
+    "name": "SARYU ROY",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jamshedpur West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jamshedpur West",
+          "party": "Janata Dal (United)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "549dc474-084c-57af-95bf-153332563c26",
+    "name": "SABITA MAHATO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Ichagarh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Ichagarh",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c10e1a38-5faa-521f-a8d7-d394c855057e",
+    "name": "CHAMPAI SOREN",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Seraikella",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Seraikella",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6567ca57-98cb-5c68-bcb4-9622c38dddd8",
+    "name": "DEEPAK BIRUA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Chaibasa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Chaibasa",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "63455a7b-291d-50cc-95c9-e5b752343a2e",
+    "name": "NIRAL PURTI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Majhgaon",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Majhgaon",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "144b22a4-ce9d-5d71-8a9f-4dde236c7dde",
+    "name": "SONA RAM SINKU",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Jaganathpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Jaganathpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4d81d5b5-68ad-5cfa-88cb-3653213778ce",
+    "name": "JAGAT MAJHI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Manoharpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Manoharpur",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "924b0a50-25bb-5902-bf17-0596c73ecec0",
+    "name": "SUKHRAM ORAON",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Chakradharpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Chakradharpur",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5cc77a47-114f-507b-ac06-522e24ae1c69",
+    "name": "DASHRATH GAGRAI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Kharsawan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Kharsawan",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8a761037-8388-5740-b1b8-b40f17d604d9",
+    "name": "VIKAS MUNDA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Tamar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Tamar",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1ca31516-5547-5260-a6a9-1261a983d072",
+    "name": "SUDEEP GUDHIYA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Torpa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Torpa",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b171553b-cd5c-56be-b784-7bcd346b4098",
+    "name": "RAM SURYA MUNDA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Khunti",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Khunti",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3cb4d082-eee0-5c41-864d-645829166a7e",
+    "name": "AMIT KUMAR",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Silli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Silli",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "62de03ac-0d41-507a-8583-9171e3187d37",
+    "name": "RAJESH KACHHAP",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Khijri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Khijri",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "11d2bc72-d411-50da-9d85-ef31bf31361e",
+    "name": "CHANDRESHWAR PRASAD SINGH",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Ranchi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Ranchi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5fcf6875-2c27-52fc-bc0d-0676c6bbc3d5",
+    "name": "NAVEEN JAISWAL",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Hatia",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Hatia",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0cd3990c-c0b5-53a5-b622-48478f8f8a1b",
+    "name": "SURESH KUMAR BAITHA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Kanke",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Kanke",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b3fbd3e4-46ec-55db-962d-6ef2e5f346cd",
+    "name": "SHIPLI NEHA TIRKEY",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Mandar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Mandar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d991a706-0768-55c4-aa7a-2961bc788892",
+    "name": "JIGA SUSARAN HORO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Sisai",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Sisai",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2e4b7153-6273-50e3-aa0c-9266cfc96112",
+    "name": "BHUSHAN TIRKEY",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Gumla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Gumla",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e5a9a20c-524c-5b98-856f-943588d14ed7",
+    "name": "CHAMRA LINDA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Bishunpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Bishunpur",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "82615604-9d72-5c10-a4de-64aa478737f8",
+    "name": "BHUSHAN BARA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Simdega",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Simdega",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c3eaeabd-baa7-52b7-89e9-dcb2fc36a2fb",
+    "name": "NAMAN VIKSAL KONGARI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Kolebira",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Kolebira",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ab5d4638-3961-50f0-aa3f-b5001189a214",
+    "name": "RAMESHWAR ORAON",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Lohardaga",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Lohardaga",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "49b28a6f-79dc-548b-89b7-ed19293c31c4",
+    "name": "RAMCHANDRA SINGH",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Manika",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Manika",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d6434e9f-c2b8-52fe-817e-c21dce1f2f2f",
+    "name": "PRAKASH RAM",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Latehar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Latehar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fc1d6bba-19a0-5bc3-9095-cae07cab4e6a",
+    "name": "KUSHWAHA SHASHI BHUSHAN MEHTA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Panki",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Panki",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bc44dc1a-99b7-50ef-9131-91ce877cd6ea",
+    "name": "ALOK KUMAR CHAURASIYA",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Daltonganj",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Daltonganj",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4dbec426-5821-5d23-81e7-14ac9ed35b60",
+    "name": "NARESH PRASAD SINGH",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Bishrampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Bishrampur",
+          "party": "Rashtriya Janata Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a9db3311-8d0a-5c94-8d43-4daba41fc475",
+    "name": "RADHA KRISHNA KISHORE",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Chhatarpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Chhatarpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eed3b3b0-ea10-548c-b333-e717d9acf4ce",
+    "name": "SANJAY KUMAR SINGH YADAV",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Hussainabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Hussainabad",
+          "party": "Rashtriya Janata Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a544d795-e2dd-5f46-9fc6-40d46e831902",
+    "name": "SATYENDRA NATH TIWARI",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Garhwa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Garhwa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7dca3969-8c64-56bd-ae13-dba60520fe43",
+    "name": "ANANT PRATAP DEO",
+    "photo": null,
+    "state": "Jharkhand",
+    "constituency": "Bhawanathpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jharkhand",
+          "constituency": "Bhawanathpur",
+          "party": "Jharkhand Mukti Morcha",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6cffe98d-18a4-53f4-8af4-53d811556492",
+    "name": "A. K. M. ASHRAF",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Manjeshwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Manjeshwar",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d463bb7d-e7c7-5023-9515-13081377617a",
+    "name": "N. A. NELLIKKUNNU",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kasaragod",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kasaragod",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "33ca49ac-8633-5995-9a2b-b20ff1e93955",
+    "name": "C. H. KUNHAMBU",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Udma",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Udma",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b27248c9-8ff7-5e19-b550-205f275492d8",
+    "name": "E. CHANDRASEKHARAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kanhangad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kanhangad",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d00eb629-7a04-5b31-9d4e-2e9e8c5c8ac4",
+    "name": "M. RAJAGOPAL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Trikaripur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Trikaripur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c461a821-e9a9-54d6-8463-42a2a3c2a518",
+    "name": "T. I. MADUSOODHANAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Payyannur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Payyannur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e19282ab-9501-567e-9963-cbaa18691eaf",
+    "name": "M. VIJIN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kalliasseri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kalliasseri",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8feab766-4ee5-59c6-827d-c4a4405a965c",
+    "name": "M. V. GOVINDAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Taliparamba",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Taliparamba",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f00be734-216c-59c7-a527-d89c07268c4b",
+    "name": "SAJU JOSEPH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Irikkur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Irikkur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5b6695c7-97e9-5328-8d5f-e6b172db5cb0",
+    "name": "K. V. SUMESH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Azhikode",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Azhikode",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fe416017-bd74-5ae6-afe1-407796d27b78",
+    "name": "RAMACHANDRAN KADANNAPPALLI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kannur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kannur",
+          "party": "C(S)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5acbce36-55cc-5aad-99df-2143da8ef994",
+    "name": "PINARAYI VIJAYAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Dharmadam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Dharmadam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7713e004-874a-56ee-aeb7-8e0d8d468ab8",
+    "name": "A. N. SHAMSEER",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thalassery",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thalassery",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bae92543-0c60-56bb-9875-cc3531579487",
+    "name": "K.P. MOHANAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kuthuparamba",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kuthuparamba",
+          "party": "Loktantrik Janata Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bd3f3a9a-c07c-55a1-a59a-9b4bf456bc92",
+    "name": "K K SHAILAJA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Mattannur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Mattannur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b93f2e20-99d6-57e7-9017-2e6d1a720734",
+    "name": "SUNNY JOSEPH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Peravoor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Peravoor",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "aa0aa6af-0110-5232-b482-241a21b49890",
+    "name": "O R KELU",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Mananthavady",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Mananthavady",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "917c55a3-8bed-5e5e-be1d-66eb41cf0684",
+    "name": "I. C. BALAKRISHNAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Sulthanbathery",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Sulthanbathery",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "53ced929-34a4-5d2b-a87a-5c6cbdd144e2",
+    "name": "T. SIDDIQUE",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kalpetta",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kalpetta",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8182dadc-14f8-504b-9949-a5475a4db580",
+    "name": "K.K.REMA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Vadakara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Vadakara",
+          "party": "RMPOI",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d36eae90-c975-50fd-819d-c9a5c69a8872",
+    "name": "K P KUNHAMMAD KUTTY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kuttiadi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kuttiadi",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0929b70a-0555-5c1b-8236-8d2032f80bc9",
+    "name": "EK VIJAYAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Nadapuram",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Nadapuram",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fe7cb1e6-7cac-5f53-92c8-b128572fd374",
+    "name": "KANATHIL JAMEELA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Quilandy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Quilandy",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6222adce-326e-5ebf-985c-e34233e4dc27",
+    "name": "T.P RAMAKRISHNAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Perambra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Perambra",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4c92e80e-ccae-5c4e-b2b0-2b1c471e73d2",
+    "name": "K.M SACHIN DEV",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Balusseri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Balusseri",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "61265aeb-44ed-5a6a-b0d9-158843553b19",
+    "name": "A. K. SASEENDRAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Elathur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Elathur",
+          "party": "Nationalist Congress Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "72a38a7d-30e4-57e3-977d-4f88f468bd17",
+    "name": "THOTTATHIL RAVEENDRAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kozhikode north",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kozhikode north",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9ccf62bc-0c8f-539d-aa19-5b46bde30595",
+    "name": "AHAMMED DEVARKOVIL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kozhikode south",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kozhikode south",
+          "party": "INL",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "67dd6d6c-a73c-5dec-93f1-f9912e56e50a",
+    "name": "P A MUHAMMAD RIYAS",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Beypore",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Beypore",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5e068e47-9839-5b53-8b6b-5e77dd49f3b7",
+    "name": "ADV. P. T. A RAHIM",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kunnamangalam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kunnamangalam",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b3d599bf-95ea-59d5-b64f-e554265c776a",
+    "name": "M K MUNEER",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Koduvally",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Koduvally",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2bd9a4a2-613f-57ea-ac04-f3cf3775eec7",
+    "name": "LINTO JOSEPH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thiruvambady",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thiruvambady",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "535e6479-bb0b-595e-9768-388f33c461c0",
+    "name": "T V IBRAHIM",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kondotty",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kondotty",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9ac6dfbb-aa21-5d7d-a57a-3ecb2602b7aa",
+    "name": "P.K. BASHEER",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Eranad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Eranad",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "babaaddd-11ea-5cda-8742-4b93eda0c083",
+    "name": "ARYADAN SHOUKATH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Nilambur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Nilambur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "db5a2827-88f5-5c20-86b1-34d9b75ed5d1",
+    "name": "AP ANIL KUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Wandoor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Wandoor",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a307fdff-3749-561d-97b8-c02db4184164",
+    "name": "ADV. U.A. LATHEEF",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Manjeri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Manjeri",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "78256c2d-3df6-5035-b975-72e794fd5574",
+    "name": "NAJEEB KANTHAPURAM",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Perinthalmanna",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Perinthalmanna",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b51ab14c-e536-50da-9118-dde3d81ef2a9",
+    "name": "MANJALAMKUZHI ALI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Mankada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Mankada",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3ad8d988-b0d1-5138-9740-0ea2813afa54",
+    "name": "P. UBAIDULLA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Malappuram",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Malappuram",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "49fb9f70-03cc-58ac-b147-6b4c3329cc19",
+    "name": "P.K KUNJHALIKUTTY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Vengara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Vengara",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2e9953fb-94d2-52e9-abc3-050e9d4733b1",
+    "name": "ABDUL HAMEED MASTER",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Vallikkunnu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Vallikkunnu",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "85863ac5-a0cd-5271-b4fb-a2718d4dac50",
+    "name": "K P A MAJEED",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Tirurangadi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Tirurangadi",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0edd8587-c296-528f-b30b-f48301b57fde",
+    "name": "V.ABDURAHIMAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Tanur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Tanur",
+          "party": "NSC",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "162f4306-1a3e-59c5-8f3f-fe892fce530e",
+    "name": "KURUKKOLI MOIDEEN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Tirur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Tirur",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "55d44aa7-d302-5733-bdd1-89c285885ceb",
+    "name": "PROF. ABID HUSSAIN THANGAL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kottakkal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kottakkal",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1ca883f1-dc35-5cf9-8134-47d005abaec8",
+    "name": "DR.K.T.JALEEL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thavanur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thavanur",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9cae6682-b5e1-50cf-8541-bd0196637193",
+    "name": "P NANDAKUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Ponnani",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Ponnani",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cc5376b7-effd-506e-993f-d1aeda8ead4e",
+    "name": "MB RAJESH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thrithala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thrithala",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2208ca50-dd82-5f64-ae36-83c6c693b14f",
+    "name": "MUHAMMED MUHSIN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Pattambi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Pattambi",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c558ff14-610a-57cd-9433-efc76541e3ec",
+    "name": "P MAMMIKUTTY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Shornur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Shornur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "646c0b3a-7dc7-51a5-a510-431dbff46c96",
+    "name": "PREM KUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Ottapalam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Ottapalam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1bae2b25-57c6-585a-a74b-cde1d192e722",
+    "name": "K. SHANTHAKUMARI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kongad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kongad",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9aa8d404-e405-5950-b99a-d68acf2ae191",
+    "name": "N. SHAMSUDHEEN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Mannarkad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Mannarkad",
+          "party": "Indian Union Muslim League",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bddc32da-5d46-5e0e-a9cd-250f95f10acb",
+    "name": "A PRABHAKARAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Malampuzha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Malampuzha",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d3cbad89-b86b-55ef-995b-6ba875c80283",
+    "name": "RAHUL MAMKOOTATHIL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Palakkad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Palakkad",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "54e390fd-4838-57b4-b946-8155f61d9d81",
+    "name": "P. P. SUMOD",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Tarur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Tarur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "036e6e63-e440-5fc4-b013-a1ac94a46d5b",
+    "name": "K. KRISHNANKUTTY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chittur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chittur",
+          "party": "Janata Dal (Secular)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6de34cf2-3288-52ba-8d69-2ce52f73503d",
+    "name": "K BABU",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Nenmara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Nenmara",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c4dd17b8-3601-596b-be28-156e34184727",
+    "name": "K D PRASENAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Alathur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Alathur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "36051ed0-9078-59fd-967b-8366eca49423",
+    "name": "U R PRADEEP",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chelakkara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chelakkara",
+          "party": "Communist Party of India (Marxist)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ad9ac9c3-cb91-51df-9af2-2c6bffeda47c",
+    "name": "A C MOIDEEN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kunnamkulam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kunnamkulam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "46d1ed16-2481-50a9-8a23-4165a8186ad4",
+    "name": "NK AKBAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Guruvayoor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Guruvayoor",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "613b9cf0-f283-5a5b-bce5-c4188617276a",
+    "name": "MURALI PERUNELLY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Manalur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Manalur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cb9e9b75-d3ae-5f53-97ef-f25d164c4d38",
+    "name": "XAVIER CHITTILAPPILLY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Wadakkanchery",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Wadakkanchery",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "67fa1140-06c6-5fe4-9492-fd7c16470e64",
+    "name": "K. RAJAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Ollur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Ollur",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d378c41e-7364-5513-9af0-d24fdd5f0fb5",
+    "name": "P. BALACHANDRAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thrissur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thrissur",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "15e8ad93-ce31-572b-b764-d17ae1033e87",
+    "name": "C. C. MUKUNDAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Nattika",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Nattika",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "32af3451-1c14-58bb-88aa-c111ce9d6f27",
+    "name": "E. T. TAISON",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kaipamangalam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kaipamangalam",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "aa96eb60-3b5f-5c89-a761-f8f1dcdaf539",
+    "name": "R. BINDU",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Irinjalakkuda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Irinjalakkuda",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8088052d-4e92-5cec-a710-916c4b351b0e",
+    "name": "K K RAMACHANDRAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Puthukkad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Puthukkad",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "47e9acb5-c51a-5c1d-99bf-723e60a0b8b4",
+    "name": "T. J. SANEESH KUMAR JOSEPH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chalakkudy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chalakkudy",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "586ef30d-3cf3-5a7e-bfdc-da5d392c1f78",
+    "name": "V. R. SUNIL KUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kodungallur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kodungallur",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "22a57246-1e09-5811-b946-4d2bcb0e49eb",
+    "name": "ELDHOSE KUNNAPPILLY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Perumbavoor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Perumbavoor",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1388c82e-047a-537c-8bef-e80f309a836e",
+    "name": "ROJI M JOHN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Angamaly",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Angamaly",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4901f4f4-10e7-590a-8342-1795d6613b6b",
+    "name": "ANWAR SADATH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Aluva",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Aluva",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "276eaa7d-9268-5796-a0b5-4b75e3fe99c1",
+    "name": "P RAJEEV",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kalamassery",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kalamassery",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "12aab079-3ef5-5891-89dd-2a8438ee941f",
+    "name": "VD SATHEESHAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Paravur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Paravur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7057b2b0-cd9e-58fd-b7a6-0bf8b5c82e39",
+    "name": "K N UNNIKRISHNAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Vypen",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Vypen",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ada88b1a-c42f-5ce0-9cd7-35df93fbacc3",
+    "name": "K J MAXI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kochi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kochi",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c4bb6137-e6d3-5d6d-898b-18a0034c157f",
+    "name": "K BABU",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thripunithura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thripunithura",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a796136b-42f3-5302-a975-0299895744fa",
+    "name": "TJ VINOD",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Eranakulam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Eranakulam",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c3ac1826-7a4a-5a6e-9078-f12f5c69e7f0",
+    "name": "UMA THOMAS",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thrikkakara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thrikkakara",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "80497eab-eaec-5195-964c-b9f606979349",
+    "name": "PV SREENIJAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kunnathunad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kunnathunad",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9f58e88b-5a01-5931-9934-0668faf55896",
+    "name": "ANOOP JACOB",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Piravom",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Piravom",
+          "party": "KEC(J)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eead0e09-1ff6-5f12-a3f2-e785b2cb8c81",
+    "name": "MATHEW KUZHELNADAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Muvattupuzha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Muvattupuzha",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "be4bf155-3ca2-5029-b5f1-d00842dc0d44",
+    "name": "ANTONY JOHN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kothamangalam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kothamangalam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1f1a78fd-da5b-5108-85db-f9ae1a588584",
+    "name": "ADVOCATE A RAJA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Devikulam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Devikulam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a209cf4b-b965-56a0-bc0c-cf32ae183826",
+    "name": "MM MANI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Udumbanchola",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Udumbanchola",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a69f6047-4107-51e4-b0da-2c0ec6c4f4c6",
+    "name": "P J JOSEPH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thodupuzha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thodupuzha",
+          "party": "Kerala Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "61bd7825-2621-5504-b97a-dd6d7b4f46ec",
+    "name": "ROSHY AUGUSTINE",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Idukki",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Idukki",
+          "party": "KEC(M)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "afe05804-fc87-560a-b4e5-2855b2bc474c",
+    "name": "VAZHOOR SOMAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Peerumade",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Peerumade",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "554286df-f7bb-5ee4-87f6-b8b4002bce08",
+    "name": "MANI C KAPPEN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Pala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Pala",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3e2d32c5-756f-5a11-ba94-a0f8c778905f",
+    "name": "ADV. MONS JOSEPH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kaduthuruthy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kaduthuruthy",
+          "party": "Kerala Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "122e463a-6107-58e6-9868-bfa3dd176b09",
+    "name": "C. K. ASHA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Vaikom",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Vaikom",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6e8e6af7-8c38-5dd8-80c6-e4f09ece1733",
+    "name": "VN VASAVAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Ettumanoor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Ettumanoor",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "de1d409a-a99a-50cd-a604-4a5f4e898487",
+    "name": "THIRUVANJOOR RADHAKRISHNAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kottayam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kottayam",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2a0527c0-91bf-5f06-8b56-a9350aef839e",
+    "name": "CHANDY OOMMEN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Puthuppally",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Puthuppally",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e01c8bc6-0c25-546c-9547-60b03f8bf067",
+    "name": "ADV. JOB MAICHIL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Changanassery",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Changanassery",
+          "party": "KEC(M)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dc1b8fd4-2271-5a71-8297-49e58d3f0885",
+    "name": "DR.N.JAYARAJ",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kanjirappally",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kanjirappally",
+          "party": "KEC(M)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6b36ea12-3d97-5dc3-806e-e239cd644453",
+    "name": "ADV. SEBASTIAN KULATHUNKAL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Poonjar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Poonjar",
+          "party": "KEC(M)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3f536c5d-a092-5599-a1ec-794b39351873",
+    "name": "DALEEMA GEORGE",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Aroor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Aroor",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2d43fae6-90c8-5116-9a08-18d0e76cb488",
+    "name": "P. PRASAD",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Cherthala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Cherthala",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fcfc7935-727a-5214-a76f-e2b26f57a4ef",
+    "name": "PP CHITHARANJAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Alappuzha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Alappuzha",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f080c3a2-472c-52ed-88ac-6caaf9529e58",
+    "name": "H SALAM",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Ambalapuzha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Ambalapuzha",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "67955ec6-b15d-5c8d-9395-560debfd6b26",
+    "name": "THOMAS K. THOMAS",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kuttanad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kuttanad",
+          "party": "Nationalist Congress Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8232e738-fa56-5468-8c3a-ed7bbcd327b5",
+    "name": "RAMESH CHENNITHALA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Haripad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Haripad",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1a7b6fd4-3b92-54f1-94d7-fa4eb67aabe8",
+    "name": "U PRATHIBHA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kayamkulam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kayamkulam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "86daa8cc-3eb7-5658-a2cb-7157b416ebff",
+    "name": "M S ARUN KUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Mavelikara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Mavelikara",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4ff86591-546c-55e2-8612-110f8fea622f",
+    "name": "SAJI CHERIYAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chengannur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chengannur",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ff010a2d-6801-5b6d-a48c-4b0b7ed0963f",
+    "name": "ADV. MATHEW T THOMAS",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thiruvalla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thiruvalla",
+          "party": "Janata Dal (Secular)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8130de38-b0fe-5f10-8431-378f73e447ba",
+    "name": "ADV. PRAMOD NARAYAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Ranni",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Ranni",
+          "party": "KEC(M)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "56461e34-3b0e-55d0-aeb6-a6e98c0d4964",
+    "name": "VEENA GEORGE",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Aranmula",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Aranmula",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eca41a5d-d35e-5c55-a3fe-33e579d29e49",
+    "name": "K U JENISH KUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Konni",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Konni",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c32206d8-7e50-5e63-b348-5c9610e860aa",
+    "name": "CHITTAYAM GOPAKUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Adoor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Adoor",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4757d5b7-464e-5775-8185-183ed3650879",
+    "name": "C. R. MAHESH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Karunagappally",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Karunagappally",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7f339b6f-4bcc-51cd-be43-4d744ec6f67d",
+    "name": "DR.SUJITH VIJAYANPILLAI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chavara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chavara",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2c3d16f3-4a5c-51e5-9af9-0b0b5a15e3f7",
+    "name": "KOVOOR KUNJUMON",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kunnathur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kunnathur",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2d72f836-b89e-542d-81b7-d34a35c9b173",
+    "name": "KN BALAGOPAL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kottarakkara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kottarakkara",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c800ac35-6932-59af-b32c-380640080f57",
+    "name": "K.B. GANESH KUMAR",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Pathanapuram",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Pathanapuram",
+          "party": "KEC(B)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d1f4c7a6-79e5-57d8-a6c2-4379abcd82b5",
+    "name": "PS SUPAL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Punalur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Punalur",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb36c7c2-ebce-5662-b258-cf15e665493e",
+    "name": "J CHINCHU RANI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chadayamangalam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chadayamangalam",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ba9b5568-73a4-5488-be74-b447245704bc",
+    "name": "P. C. VISHNUNATH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kundara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kundara",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9bf09d24-86d4-5be3-9083-19742f9affb8",
+    "name": "M MUKESH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kollam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kollam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b1f9dd60-9305-5ba5-a98b-610fe2045750",
+    "name": "M NOUSHAD",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Eravipuram",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Eravipuram",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "14d1c372-f8dd-5ed8-9810-8d3ccdd6d147",
+    "name": "GS JAYALAL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chathannur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chathannur",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "87fc029c-6fc4-5932-b4d5-81489c97d7b6",
+    "name": "V JOY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Varkala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Varkala",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6369a202-f4c9-52fe-978f-bcef75884df0",
+    "name": "O S AMBIKA",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Attingal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Attingal",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d523ae84-0e5e-53a0-a9e3-27be29279aa0",
+    "name": "V SASI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Chirayinkeezhu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Chirayinkeezhu",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4a781092-31eb-5b48-87c3-8415b3cac827",
+    "name": "GR ANIL",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Nedumangad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Nedumangad",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5fadf0a2-2fad-5d1a-a3ff-2c52445b84b4",
+    "name": "DK MURALI",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Vamanapuram",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Vamanapuram",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "97dde96e-9751-587a-a062-92b8811ff5de",
+    "name": "KADAKAMPALLY SURENDRAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kazhakkoottam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kazhakkoottam",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c3b0a041-bdc0-5d15-9433-dc447dc5b85a",
+    "name": "VK PRASANTH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Vattiyoorkavu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Vattiyoorkavu",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2a9bf8bc-b86d-509a-b154-8bc8bd00545f",
+    "name": "ADV.ANTONY RAJU",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Thiruvananthapuram",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Thiruvananthapuram",
+          "party": "Janadhipathiya Kerala Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "efe9b4c1-e490-5947-a284-ae96409d6f19",
+    "name": "V SIVANKUTTY",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Nemom",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Nemom",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d9185f5e-e409-5d07-8f62-7f3ef46440d9",
+    "name": "G STEPHAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Aruvikkara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Aruvikkara",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "48c593c6-ff04-5815-92da-309763767d87",
+    "name": "CK HAREENDRAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Parassala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Parassala",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6bfcb787-2f9c-5d88-975a-446f618f74a5",
+    "name": "IB SATHEESH",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kattakkada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kattakkada",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "223a70b3-b3f8-5ba0-891e-e4777b6e0b35",
+    "name": "M. VINCENT",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Kovalam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Kovalam",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "add02624-5b94-59b5-b087-f7f9b605c9d8",
+    "name": "K ANSALAN",
+    "photo": null,
+    "state": "Kerala",
+    "constituency": "Neyyattinkara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2021,
+          "type": "MLA",
+          "state": "Kerala",
+          "constituency": "Neyyattinkara",
+          "party": "CPM",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3b138157-bd37-526a-90a1-f850c8dc611e",
+    "name": "NARESH PURI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sujanpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sujanpur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bd6b5c0b-64e2-5bc5-b75b-05b42df4c956",
+    "name": "LAL CHAND KATARUCHAKK",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bhoa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bhoa",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3ba633ff-4693-58c1-821e-f14a99284f33",
+    "name": "ASHWINI KUMAR SHARMA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Pathankot",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Pathankot",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ed51648f-493c-5658-8c1e-f4d918b58809",
+    "name": "BARINDERJEET SINGH PAHRA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Gurdaspur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Gurdaspur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8a8695b5-ab0c-5e3f-9765-10b9f8262095",
+    "name": "ARUNA CHAUDHARY",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dina Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dina Nagar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "00246466-a099-516c-96e5-af8597319028",
+    "name": "PRATAP SINGH BAJWA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Qadian",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Qadian",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c9aff5fe-dfc0-5e45-98de-598a4a0ed8f6",
+    "name": "SHERRY KALSI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Batala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Batala",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9ad362cd-42c3-515a-8710-de2d60a3f535",
+    "name": "ADV AMARPAL SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sri Hargobindpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sri Hargobindpur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6c6703d9-b520-5c02-8e1a-98a3aeea93d6",
+    "name": "TRIPT RAJENDER SINGH BAJWA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Fatehgarh Churian",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Fatehgarh Churian",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "024df768-78f6-5261-9278-208d8ac6532a",
+    "name": "GURDEEP SINGH RANDHAWA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dera Baba Nanak",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dera Baba Nanak",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4c79e30c-4dc2-5f06-82e3-0e842f0b3f12",
+    "name": "KULDEEP SINGH DHALIWAL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Ajnala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Ajnala",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d6fabbff-e71e-53e8-b205-42ce6d72ff58",
+    "name": "SUKHWINDER SINGH SARKARIA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Raja Sansi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Raja Sansi",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bdcffdb4-c829-56ad-96c2-3cb2191b655c",
+    "name": "GANIEVE KAUR MAJITHIA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Majitha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Majitha",
+          "party": "Shiromani Akali Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "883f3ff6-e3ef-5f1e-923b-1a95c279b4c0",
+    "name": "HARBHAJAN SINGH ETO",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jandiala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jandiala",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "82b48a7a-39f1-5fbf-b118-40aee16520a2",
+    "name": "KUNWAR VIJAY PRATAP",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Amritsar North",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Amritsar North",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f60ae1d8-8fc7-5971-894b-44e32a2e1c84",
+    "name": "DR JASBIR SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Amritsar West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Amritsar West",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5cb896c4-3598-5120-a6d4-ee70a60caf1c",
+    "name": "AJAY GUPTA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Amritsar Central",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Amritsar Central",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "018fa2b4-0c01-5803-a85b-ce35024a427e",
+    "name": "JEEVANJOT KAUR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Amritsar East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Amritsar East",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d6c73a9a-44cb-58aa-abd6-5209084f1c52",
+    "name": "DR. INDERBIR SINGH NIJJAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Amritsar South",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Amritsar South",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8e8cba54-cb14-52ae-abfe-c4974e5f02fd",
+    "name": "ADC JASWINDER SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Attari",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Attari",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "01d364ca-c0e0-5729-80e2-141141e53585",
+    "name": "MANDEEP SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Tarn Taran",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Tarn Taran",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ccb3460c-0182-56ae-b9d9-d8cc45e17dc9",
+    "name": "SARWAN SINGH DHUN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Khem Karan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Khem Karan",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "61bae12a-d9fb-52d5-bc07-188f6304d6c1",
+    "name": "LALJIT SINGH BHULLAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Patti",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Patti",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "aaadb961-43ef-57be-85df-86c40af343c6",
+    "name": "MANJINDER SINGH LAPPURA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Khadoor Sahib",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Khadoor Sahib",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f3b8c693-aca1-5148-9a58-48d1bea021b9",
+    "name": "DALBIR SINGH TONG",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Baba Bakala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Baba Bakala",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5f1f8968-5922-5175-b1d2-47da01603e0a",
+    "name": "SUKHAPAL SINGH KHAIRA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bholath",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bholath",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d5c39d2c-e228-5d37-803b-4a12d936d049",
+    "name": "RANA GURJEET SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Kapurthala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Kapurthala",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "64835e9f-1502-5641-a198-30df8a3f6a24",
+    "name": "RANA INDER PARTAP SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sultanpur Lodhi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sultanpur Lodhi",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6333c268-0738-52b2-a8f2-f104ec1146cb",
+    "name": "BALWINDER SINGH DHALIWAL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Phagwara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Phagwara",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3e38ec1a-4b6c-5be2-9381-71d30ef9abe8",
+    "name": "VIKRAMJIT SINGH CHAUDHARY",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Phillaur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Phillaur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2728f023-2de3-510c-9f33-0ec13d0dd6e9",
+    "name": "INDERJIT KAUR MANN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Nakodar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Nakodar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7d8b82e7-813c-5bf4-a723-16f5036f430e",
+    "name": "HARDEV SINGH LADI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Shahkot",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Shahkot",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d017e452-8d1d-5650-975d-4821a38b5c65",
+    "name": "DCP BALKAR SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Kartarpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Kartarpur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1a67d304-b247-51ab-a242-71da1afe8a3d",
+    "name": "MOHINDER BHAGAT",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jalandhar West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jalandhar West",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "767ff632-d1ce-5d30-85f5-cad985afa69d",
+    "name": "FAUJA SINGH SARARI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jalandhar Central",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jalandhar Central",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5fb1ca2c-d1ce-5277-8cc1-b0faf05fe8b5",
+    "name": "AVTAR SINGH JUNIOR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jalandhar North",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jalandhar North",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c69aa89d-62fd-538b-b4f9-280cfbb48ecc",
+    "name": "PARGAT SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jalandhar Cantonment",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jalandhar Cantonment",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b439913b-902b-5364-9cf9-eb47849d7003",
+    "name": "SUKHWINDER SINGH KOTLI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Adampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Adampur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1e8ff0c2-ac7f-575a-809e-e6990d75a46c",
+    "name": "JANGILAL MAHAJAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Mukerian",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Mukerian",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c8636613-4d25-5a37-bd6d-585b1fc8a1ae",
+    "name": "KARAMVEER SINGH GHUMMAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dasuya",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dasuya",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8c14b179-b663-5cba-9f39-6a84c0aaee9e",
+    "name": "JASVIR SINGH RAJA GILL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Urmar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Urmar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e5f26e2e-f2bb-5f61-bde1-ae09565ad73e",
+    "name": "DR. RAVAJOT SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sham Chaurasi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sham Chaurasi",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6c76a058-b34c-55e4-b0bf-01f4930e84b2",
+    "name": "PANDIT BRAHMA SHANKAR JIMPA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Hoshiarpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Hoshiarpur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cc912753-c9da-5f93-a677-eda0743e8607",
+    "name": "DR. ISHANK KUMAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Chabbewal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Chabbewal",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "da53a69c-2a66-5bd4-b4de-f92e14a3e85d",
+    "name": "JAIKISHAN RODI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Garhshankar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Garhshankar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "332127a5-1996-5029-85a2-300919549e6d",
+    "name": "SUKHWINDER SINGH SUKHI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Banga",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Banga",
+          "party": "Shiromani Akali Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3f9c3c49-dd33-5973-9e42-828675a97bbd",
+    "name": "NACHHATAR PAL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Nawan Shahr",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Nawan Shahr",
+          "party": "Bahujan Samaj Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "819198a9-8172-550b-bc9e-d8a84839d4bc",
+    "name": "SANTOSH KATARIA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Balachaur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Balachaur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "faf244b9-7558-5d11-af5d-5a0889b4873c",
+    "name": "HARJOT SINGH BAINS",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Anandpur Sahib",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Anandpur Sahib",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c2c94bee-1385-5f6d-a138-5334042e2b00",
+    "name": "DINESH CHADHA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Rupnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Rupnagar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2ba078ef-6dc2-5c4e-9b0e-457b42ef3b7f",
+    "name": "DR CHARANJIT SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Chamkaur Sahib",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Chamkaur Sahib",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7e27933d-456a-5f48-9fc9-5edfa121ea05",
+    "name": "ANMOL GAGAN MANN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Kharar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Kharar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "323727cb-2900-5aa7-9fdf-05b646504bb6",
+    "name": "KULWANT SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "S.A.S. Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "S.A.S. Nagar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b72b722e-184e-5be0-928d-fb3a7ea5b4dd",
+    "name": "RUPINDER SINGH HAPPY",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bassi Pathana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bassi Pathana",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1d24427a-ecf8-5150-97e0-e1fe8191d3e6",
+    "name": "LAKHBIR SINGH RAI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Fatehgarh Sahib",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Fatehgarh Sahib",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "46c4608f-0da2-5720-b31c-f472ade7d0d7",
+    "name": "GURINDER SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Amloh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Amloh",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "091aa48d-c9b6-5f22-bec8-541c6f7251c9",
+    "name": "TARUNPREET SINGH SAUNDH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Khanna",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Khanna",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6c0a4c78-ce7f-5776-8ade-7c05bfaacf1f",
+    "name": "JAGTAR SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Samrala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Samrala",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "958cb9d2-6819-5d3d-b85b-4656679cf986",
+    "name": "HARDEEP SINGH MUNDIAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sahnewal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sahnewal",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "53ee6713-61d1-5cb4-ab19-5401691b3c08",
+    "name": "DALJIT SINGH 'BHOLA' GREWAL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Ludhiana East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Ludhiana East",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d2d8e653-953d-590b-a66c-4a81aaa4d5dd",
+    "name": "RAJINDER PAL KAUR CHHINA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Ludhiana South",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Ludhiana South",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "04e4c29e-650a-5ba4-b302-1a94284aedee",
+    "name": "KULWANT SINGH SIDDHU",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Atam Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Atam Nagar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0b58a69b-0f1d-5b8a-a98a-8151813f019b",
+    "name": "ASHOK 'PAPPI' PARASHAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Ludhiana Central",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Ludhiana Central",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e2e07e0f-aeb4-5ef1-9488-b8c75a9558f0",
+    "name": "SANJEEV ARORA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Ludhiana West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Ludhiana West",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7d708499-b650-5432-a940-1fa93b724708",
+    "name": "MADAN LALL BAGGA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Ludhiana North",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Ludhiana North",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "03b567d5-e95c-55f9-a335-bc2225a5e0fb",
+    "name": "JEEWAN SINGH SANGWAL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Gill",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Gill",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e39cc1ba-cfdd-5768-8f50-1e468b27e2c1",
+    "name": "MANVINDER SINGH GYASHPURA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Payal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Payal",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "819d91a6-b72b-5391-a815-9529b5f51982",
+    "name": "MANPREET SINGH AYALI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dakha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dakha",
+          "party": "Shiromani Akali Dal",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "18293671-573e-5583-8bd1-606ad198dec7",
+    "name": "HAKAM SINGH CONTRACTOR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Raikot",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Raikot",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e1fe23e3-0849-5465-8da0-eb76cb517ccf",
+    "name": "SARABJEET KAUR MANUKE",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jagraon",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jagraon",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "36fc104b-278d-518c-9d9b-e12adc89fde9",
+    "name": "MANJIT SINGH BILASPUR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Nihal Singh Wala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Nihal Singh Wala",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "10463582-e14a-5b3c-b4d4-f78ed2a50666",
+    "name": "AMRITPAL SINGH SUKHANAND",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bhagha Purana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bhagha Purana",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7a99904e-c27f-5f2a-94a5-eeb76d7e94d0",
+    "name": "DR. AMANDEEP KAUR ARORA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Moga",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Moga",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ee34e1c3-9d5f-5785-8fc5-fab3c11b33b6",
+    "name": "DEVINDER SINGH LADDI DHOS",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dharamkot",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dharamkot",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c8ea202e-b801-5b19-8fb9-b11f93051e5d",
+    "name": "NARESH KATARIA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Zira",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Zira",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6d88f3d5-5c75-5616-8a53-bfd4185480de",
+    "name": "RANVEER SINGH BHULLAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Firozpur City",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Firozpur City",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "49269b9a-c8f4-5548-9b64-4f37610352b0",
+    "name": "RAJNISH DAHIYA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Firozpur Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Firozpur Rural",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4f93051b-7d2e-522a-bb32-094397bc0a02",
+    "name": "FAUJA SINGH SRARI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Guru Har Sahai",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Guru Har Sahai",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "97573029-b51c-52b3-9656-7d36668e2c83",
+    "name": "JAGDEEP KAMBOJ",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jalalabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jalalabad",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "52a218b4-74b9-5de9-9c2f-9f2658d2bbb8",
+    "name": "NARINDERPAL SINGH SAWNA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Fazilka",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Fazilka",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6f14d493-af65-51e6-a956-f652cbd58315",
+    "name": "SANDEEP JAKHAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Abohar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Abohar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7d2c36b9-a307-5e19-885b-3a58dc083294",
+    "name": "AMANDEEP SINGH GOLDY MUSAFIR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Balluana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Balluana",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ea29cbbb-dabd-52c5-81e2-5716d0ab1451",
+    "name": "GURMEET SINGH KHUDIAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Lambi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Lambi",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "17257eda-71bb-59ed-b5a8-0bf9653347c1",
+    "name": "HARDEEP SINGH DIMPY DHILLON",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Gidderbaha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Gidderbaha",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8753069f-c824-5df7-8fbf-c9da14eea4d5",
+    "name": "DR. BALJIT KAUR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Malout",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Malout",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e8c36907-a76c-5499-be87-a58f38f5835e",
+    "name": "JAGDEEP SINGH BRAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Muktsar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Muktsar",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9b9b772a-e5cc-542b-9be9-9e67bc288ccd",
+    "name": "GURDIT SINGH SEKHON",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Faridkot",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Faridkot",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "31fa1d43-7863-5d3c-8f46-baf588bbf393",
+    "name": "KULTAR SINGH SANDHWAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Kotkapura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Kotkapura",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f1022f14-a92f-57ca-9593-79734d85ec7b",
+    "name": "AMOLAK SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Jaitu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Jaitu",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e1d7a251-f13e-58fd-a6cd-7f2e537b4768",
+    "name": "BALKAR SINGH SIDDHU",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Rampura Phul",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Rampura Phul",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "20ed543a-ddea-5316-9051-1b8c47252a07",
+    "name": "MASTER JAGSEER SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bhucho Mandi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bhucho Mandi",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "067e2b4d-a80c-5ab7-8fc4-0515342c337c",
+    "name": "JAGROOP SINGH GILL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bathinda Urban",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bathinda Urban",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2c99c94c-9567-5dbb-95e2-1e2b4cf558a7",
+    "name": "AMIT RATAN KOTFATTA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bathinda Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bathinda Rural",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a93545c7-ba31-5e8d-84ef-69c08faf01ae",
+    "name": "BALJINDER KAUR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Talwandi Sabo",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Talwandi Sabo",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e2dd81dc-e99f-5000-8f52-0477e9ca2bfa",
+    "name": "SUKHVIR MAISER KHANA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Maur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Maur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "71834d19-3507-5acd-ada3-4c6d78a67197",
+    "name": "DR VIJAY SINGLA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Mansa",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Mansa",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b21a03a1-0bc3-50ee-83d7-6b81bcb3f8ee",
+    "name": "GURPREET SINGH BANAWALI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sardulgarh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sardulgarh",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "91d12ed4-9bf2-52e7-8d62-584877c80531",
+    "name": "BUDHRAM SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Budhlada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Budhlada",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7dcecbea-ca2f-530e-8652-ce6b59047fdf",
+    "name": "BARINDER KUMAR GOYAL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Lehra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Lehra",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "da8224e1-013c-5299-b5d1-33aa659d2dc1",
+    "name": "HARPAL SINGH CHEEMA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dirba",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dirba",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "31c270b1-d294-5e59-b8f4-46f812b9dfaf",
+    "name": "AMAN AURORA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sunam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sunam",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "59924732-4f65-53b4-9d27-477f942c4c95",
+    "name": "LABH SINGH UGOKE",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Bhadaur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Bhadaur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5892ac9c-0656-53a7-841b-92372e82b901",
+    "name": "KULDEEP SINGH DHILLON",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Barnala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Barnala",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2c83173c-687a-5305-8017-100f0eee516f",
+    "name": "KULWANT PANDORI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Mehal Kalan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Mehal Kalan",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d9bf0071-3145-52c4-9eba-ec7ee7fad9e6",
+    "name": "MOHAMMED JAMIL UR RAHMAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Malerkotla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Malerkotla",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f583c8a8-813b-5a57-b2ee-860436845fc2",
+    "name": "JASWANT SINGH GAJJANAMAJRA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Amargarh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Amargarh",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f8bc5a9b-2839-5648-a7eb-ff6c2ce6e7e9",
+    "name": "BHAGWANT MAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dhuri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dhuri",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "de7d7cd9-bba9-54fc-9f49-eeb283c9cc3a",
+    "name": "NARINDER KAUR BHARAJ",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sangrur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sangrur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "68387536-ab98-5647-ba08-f4b545c569cb",
+    "name": "GURDEV SINGH DEV MAAN",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Nabha",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Nabha",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b0f406a9-3e58-50c0-bb72-7d40834c9783",
+    "name": "DOCTOR BALBIR SINGH",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Patiala Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Patiala Rural",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2e82eb5d-6a22-5867-b376-b7dd7f5714c8",
+    "name": "NINA MITTAL",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Rajpura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Rajpura",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2c792fd7-fe7d-5595-af13-55eef42f2260",
+    "name": "KULJIT SINGH RANDHAWA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Dera Bassi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Dera Bassi",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c68d7cf7-5e48-5b29-926f-c4b16a5e3eda",
+    "name": "GURLAL GHAUNAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Ghanaur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Ghanaur",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "12e288f1-f1aa-5705-ba0f-44ff139c8972",
+    "name": "HARMEET SINGH PATHANMAJRA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Sanour",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Sanour",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8ac8f139-5736-5d82-989d-a04c480c950d",
+    "name": "AJITPAL SINGH KOHLI",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Patiala",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Patiala",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "35f24950-906e-5b16-a335-299a4a6843d4",
+    "name": "CHETAN SINGH JORMAZRA",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Samana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Samana",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "854e952c-23e4-5ba7-9ba2-4a322982bb18",
+    "name": "KULWANT SINGH BAZIGAR",
+    "photo": null,
+    "state": "Punjab",
+    "constituency": "Shutrana",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2022,
+          "type": "MLA",
+          "state": "Punjab",
+          "constituency": "Shutrana",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "54544d43-f55d-50ac-bfa7-d0de99c8ef13",
+    "name": "DR. PALVAI HARISH BABU",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Sirpur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Sirpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ba7312ae-a87d-577c-97f6-7d71e51bc124",
+    "name": "DR. G. VIVEKANAND",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Chennur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Chennur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e614978e-12b0-5640-9704-4dcfd73a19bc",
+    "name": "GADDAM VINOD",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Bellampalli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Bellampalli",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c5da56f1-39e5-5738-8167-d785a2cfad54",
+    "name": "KOKKIRALA PREM SAGAR RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Mancherial",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Mancherial",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "57c6dfe8-a867-5c6f-9db6-8f2641c552f1",
+    "name": "KOVA LAXMI",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Asifabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Asifabad",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d2873205-f663-5686-b81b-dd47b57ac6f1",
+    "name": "VEDMA BHOJJU",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Khanapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Khanapur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "07de75b1-7891-576a-838e-74e151e3c621",
+    "name": "PAYAL SHANKAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Adilabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Adilabad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "09d502c0-5889-5d3e-96b7-a13daeb7c580",
+    "name": "ANIL JADHAV",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Boath",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Boath",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e0f96e72-f52a-5950-9bb7-6f99e59a188e",
+    "name": "ALETI MAHESHWAR REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nirmal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nirmal",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "137d5800-bbce-5497-9866-0a0fd299596a",
+    "name": "RAMARAO PATEL",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Mudhole",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Mudhole",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e2b22a57-1df3-5d5c-a4a7-d7a602f35ee0",
+    "name": "PAIDI RAKESH REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Armur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Armur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c3891ac7-184c-5493-a8be-ae22f0ee7f30",
+    "name": "P. SUDARSHAN REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Bodhan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Bodhan",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a3d0cb5e-9b68-5f1e-92db-7954890e26ae",
+    "name": "THOTA LAXMI KANTHA RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Jukkal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Jukkal",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "703069c5-ae2c-58bd-91a3-2acb3c90a5f3",
+    "name": "POCHARAM SRINIVAS REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Banswada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Banswada",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b69ce308-707f-596d-9b21-97e77ce9fb5f",
+    "name": "K. MADAN MOHAN RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Yellareddy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Yellareddy",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fe4f6d48-a713-5dbf-b119-b53331dc4f65",
+    "name": "K VENKATA RAMANA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Kamareddy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Kamareddy",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8b0f1477-53de-5590-bdcf-7ace8f47ef93",
+    "name": "DHANPAL SURYANARYANA GUPTA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nizamabad Urban",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nizamabad Urban",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d8987f1f-5848-5ca6-8560-849eb46be9f0",
+    "name": "DR. RECULAPALLY BHOOPATHI REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nizamabad Rural",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nizamabad Rural",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7967aae8-66f0-55d4-926d-1d40dda6aa7b",
+    "name": "VEMULA PRASHANTH REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Balkonda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Balkonda",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0deaa430-4ab7-5687-8b81-400d9ba1ac4e",
+    "name": "DR. SANJAY KALVAKUNTLA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Koratla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Koratla",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d90a39f5-0bf5-59f3-996b-928264c58d15",
+    "name": "DR. M. SANJAY KUMAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Jagtial",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Jagtial",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "60d1bc99-8774-5345-9a33-b4ccbebe6bca",
+    "name": "ADLURI LAXMAN KUMAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Dharmapuri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Dharmapuri",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4362190e-588b-56b7-a452-3f57c6148b15",
+    "name": "M.S. RAJ THAKOOR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Ramagundam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Ramagundam",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "391738b1-e599-5eb3-bcfd-27191f4142da",
+    "name": "DUDDILLA SRIDHAR BABU",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Manthani",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Manthani",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bbf3c510-c198-56f9-a7a1-2f08c8d898fe",
+    "name": "CHINTAKUNTA VIJAYA RAMANA RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Peddapalli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Peddapalli",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "63dbf80d-01bb-55ad-9407-5ffc133abcc0",
+    "name": "GANGULA KAMALAKAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Karimnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Karimnagar",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8da492eb-a135-5b08-a7db-4b290c95cb0c",
+    "name": "MEDIPALLY SATYAM",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Choppadandi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Choppadandi",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e1b21b6c-6b5b-5ca0-a9d0-e792aa1458a2",
+    "name": "AADI SRINIVAS",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Vemulawada",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Vemulawada",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c7b620bd-8495-55c4-8773-fb11e3e4dcd2",
+    "name": "KALVAKUNTLA TARAKA RAMA RAO (KTR)",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Sircilla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Sircilla",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d73b2374-b219-5e8a-a910-4572e21edb81",
+    "name": "DR. KAVVAMPALLY SATYANARAYANA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Manakondur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Manakondur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "326b15b8-9d78-59a3-b936-1b3ea851e994",
+    "name": "PADI KAUSHIK REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Huzurabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Huzurabad",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2783a0bf-edaf-53a4-8972-6be98780e289",
+    "name": "PONNAM PRABHAKAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Husnabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Husnabad",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bfe371f1-4347-55b0-b6ee-cf6fcd0d023a",
+    "name": "THANNEERU HARISH RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Siddipet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Siddipet",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "311797e0-f9af-5d4f-8c1d-392ef78d4901",
+    "name": "MYNAMPALLY ROHIT RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Medak",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Medak",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ddf09ac8-e3b7-5103-87b2-3eb586607ee3",
+    "name": "SURESH KUMAR SHETKAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Narayankhed",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Narayankhed",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "673aadd1-7de3-5510-848f-60fa81a6c9b3",
+    "name": "C. DAMODAR RAJANARSIMHA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Andole",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Andole",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4511af02-ead0-503b-baf0-037784edd860",
+    "name": "VAKITI SUNITHA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Narsapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Narsapur",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "be64be28-08b5-5f09-be91-979bcb68b651",
+    "name": "KONINTY MANIK RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Zahirabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Zahirabad",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "08af8abf-9f3f-557f-9f01-67e9efa414a1",
+    "name": "CHINTA PRABHAKAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Sangareddy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Sangareddy",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5e2cdb1a-1fba-5812-aff6-d18b2ac5aaf1",
+    "name": "GUDEM MAHIPAL REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Patancheru",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Patancheru",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "60cdf9ef-2c19-5a8b-a9c2-566f282b0d25",
+    "name": "KOTHA PRABHAKAR REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Dubbak",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Dubbak",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9d1cfabd-d472-51d0-b108-6dd1a1513658",
+    "name": "K. CHANDRASEKHAR RAO (KCR)",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Gajwel",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Gajwel",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fd473d25-0c30-5ab8-b09e-fc8057bb1738",
+    "name": "CHAMAKURA MALLA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Medchal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Medchal",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e7f6a999-f21b-5c02-999c-353f2e6e2d80",
+    "name": "RAJSHEKHAR REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Malkajgiri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Malkajgiri",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8b5a8cef-bd09-5e6a-bb6a-996341e62aed",
+    "name": "KUNA PANDU VIVEKANAND",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Quthbullapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Quthbullapur",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0755788f-e606-5e6f-9fbe-917216ed21b8",
+    "name": "MADHAVARAM KRISHNA RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Kukatpally",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Kukatpally",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c4537ea3-4339-51ba-b571-89ab4ed4bfed",
+    "name": "BANDARU LAKSHMA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Uppal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Uppal",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "30f57107-37af-5215-8f84-1afda192ddcc",
+    "name": "MALREDDY RANGA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Ibrahimpatnam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Ibrahimpatnam",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d6359038-b93f-5f53-ab77-fea15157da72",
+    "name": "DEVIREDDY SUDHEER REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Lal Bahadur Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Lal Bahadur Nagar",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8688d950-9b98-5732-8f27-0cb6645af5c9",
+    "name": "PATLOLLA SABITHA INDRA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Maheshwaram",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Maheshwaram",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ec13f921-d3d1-5a3e-bba5-c8d542c4bafd",
+    "name": "TOLKANTI PRAKASH GOUD",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Rajendranagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Rajendranagar",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "60b65da0-6696-54e7-8222-6ca098ee1cf1",
+    "name": "AREKAPUDI GANDHI",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Serilingampally",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Serilingampally",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "794b0fac-6de3-5eea-b578-636417fa6251",
+    "name": "KALE YADAIAH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Chevella",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Chevella",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b8224baa-ecbd-53bc-9e41-20213f658bf1",
+    "name": "T. RAM MOHAN REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Pargi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Pargi",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "34fb3099-5df4-5d2c-b4ce-7db8c344383d",
+    "name": "GADDAM PRASAD KUMAR",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Vikarabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Vikarabad",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "df79de59-f598-5088-a611-99ea58efa384",
+    "name": "BUYYANI MANOHAR REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Tandur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Tandur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "250fc34d-308d-5802-a5d2-b455c86bcadb",
+    "name": "MUTA GOPAL",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Musheerabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Musheerabad",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e842d4fb-f0cf-5204-ad3a-fa1a85a319a3",
+    "name": "AHMED BIN ABDULLAH BALALA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Malakpet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Malakpet",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7fe38631-810d-54fb-a765-821ed7984ba8",
+    "name": "KALERU VENKATESH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Amberpet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Amberpet",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e679f39e-e9ad-548f-892a-46e0f99c3e93",
+    "name": "DANAM NAGENDER",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Khairatabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Khairatabad",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "50380537-4ed3-5621-a6cd-a659ce4116ce",
+    "name": "NAVEEN YADAV",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Jubilee Hills",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Jubilee Hills",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bcbb5abf-d796-5142-96c1-55a2b54a636d",
+    "name": "TALASANI SRINIVAS YADAV",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Sanathnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Sanathnagar",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a7e6a556-0f9d-5888-8f3b-8ea80034159c",
+    "name": "MAJEED HUSSAIN",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nampalli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nampalli",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "df6777eb-36a1-5016-b380-3ae9ac2ab4ff",
+    "name": "KAUSAR MOHIUDDIN",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Karwan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Karwan",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ff888744-92ca-581d-b898-96b8569c48d4",
+    "name": "T RAJA SINGH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Goshamahal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Goshamahal",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "808161c7-d3a4-5860-9569-20939e5d63de",
+    "name": "MIR ZULFEQAR ALI",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Charminar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Charminar",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "38291bba-f2de-597f-aaf6-5a49a9f666f7",
+    "name": "AKBARUDDIN OWAISI",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Chandrayangutta",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Chandrayangutta",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "854320c4-9ecf-51cd-8dc7-bc2447045e04",
+    "name": "JAFFER HUSSAIN",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Yakutpura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Yakutpura",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d30080b4-c159-5701-b7c9-d3ade5a09249",
+    "name": "MOHAMMED MUBEEN",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Bahdurpura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Bahdurpura",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1e17ad44-15c9-563d-b825-7cbb02ee9388",
+    "name": "T. PADMA RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Secunderabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Secunderabad",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5142ee06-97a2-5c6a-aee0-fb8ed2b62c14",
+    "name": "SRIGANESH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Secunderabad Cantt.",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Secunderabad Cantt.",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ab01d37e-fd69-5887-a7d3-1ce5cdf20fe8",
+    "name": "ANUMULA REVANTH REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Kodangal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Kodangal",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "de84640b-c5ae-56cd-bc31-b954f3f4ce6e",
+    "name": "PARNIKA CHITTEM REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Narayanpet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Narayanpet",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fa1e6e3b-dee9-5834-93be-e01a82cf6025",
+    "name": "YENNAM SRINIVAS REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Mahbubnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Mahbubnagar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2a3a151f-6d8a-5d1f-bd73-7d118a5ed426",
+    "name": "J.ANIRUDH REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Jadcherla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Jadcherla",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fc39ad56-bfc2-5b41-812b-df527328fefb",
+    "name": "GAVINOLLA MADHUSUDHAN REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Devarkadra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Devarkadra",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a1895309-516f-5f89-9ad9-5cb06e813276",
+    "name": "VAKITI SRIHARI",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Makthal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Makthal",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f308c867-10ae-51d4-a748-336213b7a10a",
+    "name": "TUDI MEGHA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Wanaparthy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Wanaparthy",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f9c16e67-a90e-57ff-aab7-77fd75f82aab",
+    "name": "BANDLA KRISHNA MOHAN REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Gadwal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Gadwal",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6667926d-169e-513b-ab78-12053ce30c15",
+    "name": "V.M. ABRAHAM",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Alampur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Alampur",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "846700a9-4442-59be-bd8d-71c2678ee109",
+    "name": "DR. KUCHAKULLA RAJESH REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nagarkurnool",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nagarkurnool",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "faf3e77a-0a31-593f-9cd5-58a02a0ce7fd",
+    "name": "CHIKKUDU VAMSHI KRISHNA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Achampet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Achampet",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b7ef50ea-21ec-5f6b-842f-266649762aca",
+    "name": "KASIREDDY NARAYAN REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Kalwakurthy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Kalwakurthy",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "15663a91-64d0-5fca-bcb9-2c1cd3b0d564",
+    "name": "K. SHANKARAIAH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Shadnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Shadnagar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "64071b2c-6d85-5214-afe8-5cca4c8ec2e1",
+    "name": "JUPALLY KRISHNA RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Kollapur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Kollapur",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "3dc97874-418a-511f-b1a5-15cc9755624a",
+    "name": "NENAVATH BALU NAIK",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Devarakonda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Devarakonda",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9d4f4c29-4e41-51cb-b6ff-4e52c5bb0658",
+    "name": "JAYAVEER KUNDURU",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nagarjuna Sagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nagarjuna Sagar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "48919a88-b68d-549b-8449-d87c5372d230",
+    "name": "BHATULA LAXMANA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Miryalguda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Miryalguda",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ae173384-4eab-5e4e-9a9c-f12057a7930b",
+    "name": "NALAMADA UTTAM KUMAR REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Huzurnagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Huzurnagar",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d76c917c-b787-5d27-a162-ee67a1a280ff",
+    "name": "SMT. NALAMADA PADMAVATHI REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Kodad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Kodad",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c03c5701-e893-5c4d-911d-8a4401b61bcc",
+    "name": "GUNTAKANDLA JAGADISH REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Suryapet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Suryapet",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "63886ea3-5a49-5546-a263-e056ac7c5140",
+    "name": "KOMATIREDDY VENKAT REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nalgonda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nalgonda",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d42b5d4a-7295-5e07-bc7c-17c9fe045f84",
+    "name": "K. RAJGOPAL REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Munugode",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Munugode",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "999498d9-6126-5e0c-86c9-10b27959b903",
+    "name": "KUMBAM ANIL KUMAR REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Bhongir",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Bhongir",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6c7990e1-2531-5cac-a905-3f5a654f85ee",
+    "name": "VEMULA VEERASHAM",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Nakrekal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Nakrekal",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dc017a93-7da2-5dac-98f3-07b9fe820bd2",
+    "name": "MANDULA SAMUAL",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Thungathurthy",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Thungathurthy",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "afbba2b7-2cf5-5ac1-9193-3898834a2ca9",
+    "name": "BEERLA ILAIAH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Alair",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Alair",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c276bea0-b1cd-5e81-8b40-091676a0bfc9",
+    "name": "PALLA RAJESHWAR REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Jangaon",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Jangaon",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "d629786b-f088-53bc-a8e3-ef1590dab873",
+    "name": "KADIYAM SRIHARI",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Ghanpur Station",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Ghanpur Station",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0f9abe0d-783a-587e-9fda-5826eef387c7",
+    "name": "YESHASHWANI MEMIDILA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Palakurthi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Palakurthi",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e61552d9-1939-513e-b63d-546a7c9baa07",
+    "name": "DR.JATOTH RAMACHANDRU NAIK",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Dornakal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Dornakal",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f20de8a0-6afa-51b4-a065-c4381516af77",
+    "name": "MURALI NAIK",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Mahabubabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Mahabubabad",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "30a972b5-e49a-58e9-9cd8-9f10ac922bbb",
+    "name": "DONTHI MADHAVA REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Narsampet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Narsampet",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "819b15f8-f937-5d57-89c0-c041ea0642b1",
+    "name": "REVURI PRAKASH REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Parkal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Parkal",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "711ec162-7042-5cc8-a758-f97d2a7151ed",
+    "name": "NAINI RAJENDER REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Warangal West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Warangal West",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9d042d64-8760-5aa3-8cb7-348e511be614",
+    "name": "KONDA SUREKHA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Warangal East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Warangal East",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "77adb514-a8c7-5ad9-bfa7-50b05e18bfac",
+    "name": "K.R. NAGA RAJU",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Wardhannapet",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Wardhannapet",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b83f4520-506b-5e71-9d75-2c3219ff7a75",
+    "name": "GANDRA SATYANARAYANA RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Bhupalpalle",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Bhupalpalle",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fab0a4c1-47c2-53ce-979b-76f1a76ba300",
+    "name": "SMT. DANASARI ANASUYA SEETHAKKA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Mulug",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Mulug",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cd3d89be-4fc5-51d2-9958-7365c8351d15",
+    "name": "PAYAM VENKATESWARLU",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Pinapaka",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Pinapaka",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9aca644f-cbe5-5476-b037-4ca1bd5e5840",
+    "name": "KORAM KANAKAIAH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Yellandu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Yellandu",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eb047eb6-5d7c-50ed-9a5f-57a59c4caa69",
+    "name": "TUMLA NAGESHWAR RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Khammam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Khammam",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0465d787-0d49-54e1-b9e1-9e50287d08e0",
+    "name": "PONGULETI SRINIVAS REDDY",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Palair",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Palair",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1f450dfc-9766-5863-a854-305f93689cd9",
+    "name": "BHATTI VIKRAMARKA MALLU",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Madhira",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Madhira",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ee593506-9c69-508b-9c5d-cc5be3274e6a",
+    "name": "RAMDAS MALOTH",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Wyra",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Wyra",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "72b54d27-5dac-5ce2-a427-63121238f98f",
+    "name": "DR. MATTA RAGAMAYEE",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Sathupalli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Sathupalli",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4692e377-bdb3-55a0-afd0-0b6a66b5f8e7",
+    "name": "KUNAMNENI SAMBASIVA RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Kothagudem",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Kothagudem",
+          "party": "Communist Party of India",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e9cb72a1-205c-567f-9a45-abacd2e8aa31",
+    "name": "JARE ADHINARAYANA",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Aswaraopeta",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Aswaraopeta",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8454e7fb-a24f-5c22-8085-8981bf3702f5",
+    "name": "DR. TELLAM VENKAT RAO",
+    "photo": null,
+    "state": "Telangana",
+    "constituency": "Bhadrachalam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2023,
+          "type": "MLA",
+          "state": "Telangana",
+          "constituency": "Bhadrachalam",
+          "party": "Bharat Rashtra Samithi",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8efaf811-428b-5245-9fd7-125e01d729f4",
+    "name": "JAVID MIRCHAL",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Karnah",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Karnah",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b3f6822f-80b3-55f0-87d7-7490dd11d183",
+    "name": "JAVID HASSAN BAIG, MIR IQBAL AHMAD",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Baramulla",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Baramulla",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f889c3c9-be8e-58bc-b5f5-ad7a8b78f4f9",
+    "name": "PIRZADA FAROOQ AHMED SHAH",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Gulmarg",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Gulmarg",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "86d411c4-0db3-569f-9290-4d2c0b87614d",
+    "name": "IRFAN HAFIZ LONE",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Wagoora - Kreeri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Wagoora - Kreeri",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7de1c8e0-2184-5c24-b7e0-06c3c425d7f1",
+    "name": "JAVAID RIYAZ",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Pattan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Pattan",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4259b4d4-3194-56e7-9aa1-83bb82ec9f11",
+    "name": "HILAL AKBAR LONE",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Sonawari",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Sonawari",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "542939fb-be9c-519d-9ab3-613941cff15c",
+    "name": "NIZAM UDDIN BHAT",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Bandipora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Bandipora",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8529261b-58ca-5863-87e0-3685a7ff1812",
+    "name": "NAZIR AHMAD GUREZI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Gurez",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Gurez",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ea3df13f-390c-5ffb-a128-644a2144db74",
+    "name": "MIAN MEHAR ALI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Kangan",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Kangan",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6b0d0a33-62f8-552e-a914-c55dbb71efbb",
+    "name": "OMAR ABDULLAH",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Ganderbal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Ganderbal",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "89d998f8-0f01-55db-bdf7-4b1e28e30265",
+    "name": "SALMAN ALI SAGAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Hazratbal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Hazratbal",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "44351933-9ea6-52d5-8ef6-6c6babce90d1",
+    "name": "MIR SAIFULLAH",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Trehgam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Trehgam",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "32e16fba-fbfe-5873-a05e-0d43b9a4f988",
+    "name": "ALI MOHAMMAD SAGAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Khanyar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Khanyar",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a3809f91-50a7-5cc2-a405-26eaae80be49",
+    "name": "SHAMEEMA FIRDOUS",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Habba kadal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Habba kadal",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bf2ac248-e83b-536d-be0e-ccb75858ab62",
+    "name": "SHEIKH AHSAN AHMED",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Sonawar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Sonawar",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5a5d275e-ce85-508d-9217-e1ab25d4420f",
+    "name": "MUSHTAQ GUROO",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Channapora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Channapora",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ade4e72c-aa05-5f9a-ba12-d54cd12c8778",
+    "name": "TANVIR SADIQ",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Zadibal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Zadibal",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5c3fa975-4345-5d46-ab6e-8c1dda031c7d",
+    "name": "MUBARAK GUL",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Eidgah",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Eidgah",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c961c62d-b535-521d-b350-9eceb00243c0",
+    "name": "TARIQ HAMEED KARRA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Central Shalteng",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Central Shalteng",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f7f19e79-1878-5323-954f-de923f9e16ee",
+    "name": "AGA SYED MUNTAZIR MEHDI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Budgam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Budgam",
+          "party": "Jammu & Kashmir Peoples Democratic Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fa1e4e43-83ec-5cb5-8686-377bcf291ffb",
+    "name": "SHAFI AHMAD WANI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Beerwah",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Beerwah",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "55ea0c21-1e20-59b9-8729-df9ccaba01ff",
+    "name": "SAIF-UD-DIN BHAT",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Khan Sahib",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Khan Sahib",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "740b0c23-baea-5c4d-8a74-151a5494dacd",
+    "name": "MIR MOHAMMAD FAYAZ",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Kupwara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Kupwara",
+          "party": "Jammu & Kashmir Peoples Democratic Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "af535447-a3a2-50f3-967d-385b51d93cc4",
+    "name": "ADVOCATE ABDUL RAHEEM RATHER",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Chrar-i-sharief",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Chrar-i-sharief",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "a2c9f2c8-20fb-5f7c-ab42-cb8b474f1895",
+    "name": "ALI MOHAMMAD DAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Chadoora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Chadoora",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "173b87d3-dc32-5d73-8469-9322a05dccf8",
+    "name": "HASNAIN MASSODI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Pampore",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Pampore",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "54c8cc2f-9147-5c9a-915f-e26d8cb67b54",
+    "name": "RAFIQ AHMAD NAIK",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Tral",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Tral",
+          "party": "Jammu & Kashmir Peoples Democratic Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cc5ea9b2-5712-5889-9489-252eaff46f9e",
+    "name": "WAHEED-UR REHMAN PARRA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Pulwama",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Pulwama",
+          "party": "Jammu & Kashmir Peoples Democratic Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ea883d4d-c44d-5daa-b1ec-66de2b8caff4",
+    "name": "MOHI-UD-DIN MIR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Rajpora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Rajpora",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bcb82319-66d6-580d-b795-6ea4cc90e4b8",
+    "name": "SHOWKAT HUSSAIN GANIE",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Zainapora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Zainapora",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e2757536-9855-53e0-b19e-e7100c13d8df",
+    "name": "SHABIR AHMAD KULLAY",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Shopian",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Shopian",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bcc85e5e-ef90-510b-b971-f9d3ec659093",
+    "name": "SAKINA ITTOO",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "D.H. Pora",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "D.H. Pora",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bcb7ac23-86ed-5057-ba09-94d01b70275f",
+    "name": "MUHAMMAD YUSUF TARIGAMI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Kulgam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Kulgam",
+          "party": "Communist Party of India (Marxist)",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7064127a-6a9c-5494-94e3-fb2e77396d73",
+    "name": "QAYASR JAMSHAID LONE",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Lolab",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Lolab",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "32f088dd-6feb-5432-ba74-119c41f5167f",
+    "name": "PEERZADA FEROZE AHAMAD",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Devsar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Devsar",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "76feea75-da7a-5e90-8f0b-b0970ac20c15",
+    "name": "GHULAM AHMAD MIR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Dooru",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Dooru",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6e24bbc2-f903-590e-b466-562eb6986b87",
+    "name": "ZAFAR ALI KHATANA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Kokernag",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Kokernag",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dff8516a-6491-5298-90fb-314706dd4985",
+    "name": "ABDUL MAJEED LARMI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Anantnag West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Anantnag West",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eb190aab-02a3-5bae-bc99-7e7fd29a68c2",
+    "name": "PEERZADA MOHAMMAD SYED",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Anantnag",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Anantnag",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1de4e75d-4596-5765-af6f-c231869e8a94",
+    "name": "BASHIR AHMAD VEERI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Bijbehara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Bijbehara",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dcf0d9e8-f52c-587f-b3dc-44a6899704df",
+    "name": "REYAZ AHMAD KHAN",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Shangus",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Shangus",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1e26d911-787d-5315-aab8-be5d4eadac54",
+    "name": "ALTAF AHMAD KALOO",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Pahalgam",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Pahalgam",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ebece253-4769-5bf8-8397-a83e9572607f",
+    "name": "PAYARE LAL SHARMA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Inderwal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Inderwal",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cc4e66c2-2572-5f88-9c24-3311bf88e5f2",
+    "name": "SHAGUN PARIHAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Kishtwar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Kishtwar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4bb77e7e-d609-5907-8039-1d7ed828ee22",
+    "name": "SAJAD GANI LONE",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Handwara",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Handwara",
+          "party": "Jammu & Kashmir Peoples Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "83bb43a8-6646-5797-acce-638a8a0828fa",
+    "name": "SUNIL KUMAR SHARMA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Padder - Nagseni",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Padder - Nagseni",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4a406d6c-7d52-5fe9-a729-5eeebf5e4bfc",
+    "name": "DALEEP SINGH PARIHAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Bhaderwah",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Bhaderwah",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "36d137ca-d4e1-5144-a14c-6bfdc70d6857",
+    "name": "MEHRAJ MALIK",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Doda",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Doda",
+          "party": "Aam Aadmi Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "6067f998-c854-5d15-9d40-5021becfbdb2",
+    "name": "SHAKTI RAJ PARIHAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Doda West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Doda West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5aacbc47-86df-5255-89c5-054fc9414b12",
+    "name": "ARJUN SINGH RAJU",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Ramban",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Ramban",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9e8c6fc4-e166-5e81-9926-1b13154bd364",
+    "name": "SAJAD SHAHEEN",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Banihal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Banihal",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "50cd3b34-6529-574a-8887-0401148221f4",
+    "name": "ER. KHURSHEED",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Gulab Garh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Gulab Garh",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "49749039-9124-5d9f-b104-5ce22cc2dcee",
+    "name": "KULDEEP RAJ DUBEY",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Reasi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Reasi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "161aba42-5eb0-59a2-8ed2-5dadab25dc60",
+    "name": "BALDEV RAJ SHARMA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Shri Mata Vaishno Devi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Shri Mata Vaishno Devi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "f19db1bd-9bc0-5689-8bb8-b19d5fd3852d",
+    "name": "PAWAN KUMAR GUPTA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Udhampur West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Udhampur West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "42aa49e1-3a13-5b51-9fec-9e99973f6eda",
+    "name": "KHURSHEED AHMAD SHIEKH",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Langate",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Langate",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "987332fc-a634-5934-9593-9312b8ae1472",
+    "name": "RANBIR SINGH PATHANIA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Udhampur East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Udhampur East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "8a9b5117-4937-5aec-8b9c-24052d6df2ac",
+    "name": "BALWANT SINGH MANKOTIA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Chenani",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Chenani",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "98a82727-506a-59f4-97ed-a31f96105fa6",
+    "name": "SUNIL BHARDWAJ",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Ram Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Ram Nagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "37ce695f-0518-5fee-b7ba-43a3777ebaad",
+    "name": "DR RAMESHWAR SINGH",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Bani",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Bani",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "85552c22-b6a4-5102-aeb9-d7e72a48e81a",
+    "name": "SATISH KUMAR SHARMA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Billawar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Billawar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "30d65973-5f65-56c0-932e-3a4427f2f873",
+    "name": "DARSHAN SINGH",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Basohli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Basohli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bc9342b9-f10c-5d54-9d4e-7e3a73fd270f",
+    "name": "RAJIV JASROTIA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Jasrota",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Jasrota",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "1541a032-1c1a-502f-975b-323bacc74544",
+    "name": "DR BHARAT BHUSHAN",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Kathua",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Kathua",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "39076a59-097e-5201-9338-574b54371bca",
+    "name": "VIJAY KUMAR SHARMA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Hira Nagar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Hira Nagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9e562568-301b-5d1d-be90-76a1b0670500",
+    "name": "DEVINDER KUMAR MANYAL",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Ramgarh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Ramgarh",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b2b2e3f2-aec5-5222-b1f4-3f75b0b0ee04",
+    "name": "IRSHAD RASOOL KAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Sopore",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Sopore",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eb4ce44a-2044-52ff-b865-3cb15fd21f50",
+    "name": "SURJIT SINGH SALATHIA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Samba",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Samba",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "e2d7f2f4-2475-5311-9f74-ae0dff7c72d7",
+    "name": "CHANDRA PRAKASH GANGA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Vijay pur",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Vijay pur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "cb1a6e45-c564-5e0a-b35a-2be9cc0e8ed1",
+    "name": "RAJEEV KUMAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Bishnah",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Bishnah",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "96b6948a-1a05-50d8-8a5e-fe4ffbc07706",
+    "name": "GHARU RAM BHAGAT",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Suchet Garh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Suchet Garh",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "9c196010-1e06-59cf-9675-6747926fb2bb",
+    "name": "NARINDER SINGH RAINA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Ranbir singh Pura",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Ranbir singh Pura",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "191729c6-f4de-590e-9bbd-28b777272eed",
+    "name": "VIKRAM RANDHAWA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Bahu",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Bahu",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "27264914-fd6c-567d-a563-a7fae2fdd9cb",
+    "name": "YUDHVIR SETHI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Jammu East",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Jammu East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "b532b8e6-1cb2-54be-8dd7-11ead1e54a66",
+    "name": "DEVYANI RANA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Nagrota",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Nagrota",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "4c2b99d9-d7a8-5f35-8d46-3a9370da088c",
+    "name": "SHAM LAL SHARMA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Jammu North",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Jammu North",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c2489635-d5fd-5fe1-ae1c-fc1bf20abac5",
+    "name": "JAVID AHMAD DAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Rafiabad",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Rafiabad",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "2ee7f104-9d98-51a1-b83b-4d0bb71ae18b",
+    "name": "SURINDER KUMAR",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Marh",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Marh",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "5a0d61e5-8f91-51e9-9dd1-4906ab691feb",
+    "name": "MOHAN LAL BHAGAT",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Akhnoor",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Akhnoor",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "c5bcf18d-7539-50ff-85d8-7abaac63723c",
+    "name": "SATISH SHARMA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Chhamb",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Chhamb",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "fb244668-13d0-5d05-bc4e-6edbeacc9b0a",
+    "name": "SURINDER CHOWDARY",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Nowshera",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Nowshera",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "7878a6b1-b39f-5dfe-8c36-aec5cc689c7a",
+    "name": "IFTKAR AHMED",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Rajouri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Rajouri",
+          "party": "Indian National Congress",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "57a6b85a-89ae-57cf-b6a6-cc4e58daa17f",
+    "name": "JAVID CHOWDARY",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Darhal",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Darhal",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "da21e2f7-fa06-5000-8110-4deba53a5fb2",
+    "name": "MUZAFFAR IQBAL KHAN",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Thannamandi",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Thannamandi",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bb4cd309-5e57-5856-8142-ba2e1da8c946",
+    "name": "CHOUDHARY MOHAMMED AKRAM",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Surankote",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Surankote",
+          "party": "Independent",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "92e2c9c4-85c7-5707-9f2f-9498972a03f2",
+    "name": "AJAZ AHMAD JAN",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Poonch Haveli",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Poonch Haveli",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "bfbe1e50-a959-5422-b847-37341b62ba2b",
+    "name": "DR. SAJAD SHAFI URI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Uri",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Uri",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "efe62d17-50d0-589c-8f2c-2ff771e3a89a",
+    "name": "JAVED AHMED RANA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Mendhar",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Mendhar",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "0e1afcf5-7074-5f31-87b0-4144c28003ff",
+    "name": "ARVIND GUPTA",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Jammu West",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Jammu West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON"
+        }
+      ]
+    }
+  },
+  {
+    "id": "432811e8-6258-51db-8ff3-896276ac7236",
+    "name": "ABDUL GAFFAR PAHARI",
+    "photo": null,
+    "state": "Jammu and Kashmir",
+    "constituency": "Poonch",
+    "type": "MLA",
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Jammu and Kashmir",
+          "constituency": "Poonch",
+          "party": "Jammu & Kashmir National Conference",
+          "status": "WON"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## What does this PR do?

Adds base MLA records for 8 states that had zero representation in `mla.json`. All records follow the existing schema with UUID5 IDs, constituency names, party affiliations, and election results.

## Type of change

- [x] Data contribution (added/updated MLA records)

## Scope

867 new MLA records across 8 states:

| State | MLAs | Election Year |
|-------|------|---------------|
| Uttarakhand | 70 | 2022 |
| Gujarat | 182 | 2022 |
| Himachal Pradesh | 68 | 2022 |
| Punjab | 117 | 2022 |
| Kerala | 140 | 2021 |
| Telangana | 119 | 2023 |
| Jharkhand | 81 | 2024 |
| Jammu and Kashmir | 90 | 2024 |

Total records in `mla.json`: 2,386 → 3,253

