### PR TITLE
fix: resolve 3 bugs blocking enrichment agent LLM pipeline

### DIFF
--- a/app/agents/base_agent.py
+++ b/app/agents/base_agent.py
@@ -182,10 +182,12 @@ class BaseAgent:
             content = response.content if hasattr(response, "content") else str(response)
             if isinstance(content, list):
                 content = "".join(
-                    part if isinstance(part, str) else part.get("text", str(part))
+                    part if isinstance(part, str)
+                    else part.get("text", str(part)) if isinstance(part, dict)
+                    else getattr(part, "text", str(part))
                     for part in content
                 )
-            return content
+            return str(content) if not isinstance(content, str) else content
         except Exception as exc:
             self._record_error("llm", str(exc), exc=exc)
             raise

--- a/app/agents/base_agent.py
+++ b/app/agents/base_agent.py
@@ -179,7 +179,13 @@ class BaseAgent:
         """Send a prompt to the LLM and return plain text."""
         try:
             response = self.llm.invoke(prompt)
-            return response.content if hasattr(response, "content") else str(response)
+            content = response.content if hasattr(response, "content") else str(response)
+            if isinstance(content, list):
+                content = "".join(
+                    part if isinstance(part, str) else part.get("text", str(part))
+                    for part in content
+                )
+            return content
         except Exception as exc:
             self._record_error("llm", str(exc), exc=exc)
             raise

--- a/app/config/free_tier_llm.py
+++ b/app/config/free_tier_llm.py
@@ -48,7 +48,7 @@ def _float_env(name: str, default: float) -> float:
 
 
 # Hard timeout per candidate call so failover cannot stall indefinitely.
-_REQUEST_TIMEOUT_SECS = _float_env("FREE_TIER_LLM_TIMEOUT_SECS", 7.0)
+_REQUEST_TIMEOUT_SECS = _float_env("FREE_TIER_LLM_TIMEOUT_SECS", 15.0)
 
 # ---------------------------------------------------------------------------
 # 1. Provider config schema
@@ -93,7 +93,6 @@ DEFAULT_PROVIDERS: list[dict[str, Any]] = [
     {"provider": "gemini", "model": "gemini-3.1-pro-preview", "api_key_env": "GEMINI_API_KEY"},
     {"provider": "gemini", "model": "gemini-3-flash-preview", "api_key_env": "GEMINI_API_KEY"},
     {"provider": "gemini", "model": "gemini-2.5-pro", "api_key_env": "GEMINI_API_KEY"},
-    {"provider": "gemini", "model": "gemini-3-flash", "api_key_env": "GEMINI_API_KEY"},
     {"provider": "gemini", "model": "gemini-2.5-flash", "api_key_env": "GEMINI_API_KEY"},
     {"provider": "gemini", "model": "gemini-2.0-flash", "api_key_env": "GEMINI_API_KEY"},
     # --- Groq (ultra-fast free inference) ---
@@ -240,11 +239,14 @@ def _is_retryable(exc: Exception) -> bool:
     if class_name in {"AuthenticationError", "PermissionDenied", "Unauthorized"}:
         return False
 
-    # Pure validation errors (but not quota/rate messages)
+    # Pure validation errors (but not quota/rate messages).
+    # Model-not-found (404) should always failover to the next candidate.
+    if status_code == 404:
+        return True
     if status_code == 400:
         msg = exc_str.lower()
         if "invalid" in msg and "quota" not in msg and "rate" not in msg:
-            return False
+            return True  # fail over so bad model configs don't block the chain
 
     # Known retryable HTTP status codes (rate-limit, server errors)
     if status_code in {429, 500, 502, 503, 504, 529}:

--- a/app/config/free_tier_llm.py
+++ b/app/config/free_tier_llm.py
@@ -239,14 +239,15 @@ def _is_retryable(exc: Exception) -> bool:
     if class_name in {"AuthenticationError", "PermissionDenied", "Unauthorized"}:
         return False
 
-    # Pure validation errors (but not quota/rate messages).
-    # Model-not-found (404) should always failover to the next candidate.
+    # Model/config errors — failover to the next candidate so that
+    # a single bad model entry (wrong name, invalid deadline, etc.)
+    # does not block the entire chain.
     if status_code == 404:
         return True
     if status_code == 400:
         msg = exc_str.lower()
         if "invalid" in msg and "quota" not in msg and "rate" not in msg:
-            return True  # fail over so bad model configs don't block the chain
+            return True
 
     # Known retryable HTTP status codes (rate-limit, server errors)
     if status_code in {429, 500, 502, 503, 504, 529}:

--- a/app/data/mp.json
+++ b/app/data/mp.json
@@ -4946,7 +4946,32 @@
       }
     ],
     "criminal_records": [],
-    "family_background": [],
+    "family_background": [
+      {
+        "name": "Shivappa Shettar",
+        "relation": "FATHER",
+        "photo": null,
+        "social_media": null
+      },
+      {
+        "name": "Shilpa Shettar",
+        "relation": "WIFE",
+        "photo": null,
+        "social_media": null
+      },
+      {
+        "name": "Prashant Shettar",
+        "relation": "SON",
+        "photo": null,
+        "social_media": null
+      },
+      {
+        "name": "Sankalp Shettar",
+        "relation": "SON",
+        "photo": null,
+        "social_media": null
+      }
+    ],
     "contact": {
       "email": null,
       "phone": null,


### PR DESCRIPTION
## Summary

The enrichment agent (`run_politician_agent.py`) was hitting a **100% failure rate** on all LLM calls due to three interconnected bugs. This PR fixes all three.

## Bug 1: LLM timeout too short (7s → 15s)

The default `_REQUEST_TIMEOUT_SECS` was set to `7.0` in `free_tier_llm.py:51`. The Gemini API enforces a minimum deadline of 10 seconds, causing every call to fail with:

```
400 INVALID_ARGUMENT: Manually set deadline 7s is too short. Minimum allowed deadline is 10s.
```

**Evidence:** The 10s minimum is enforced server-side — the error payload above is the exact response from `generativelanguage.googleapis.com`. This is not documented in the Gemini troubleshooting guide, but is enforced at runtime by the API.

**Fix:** Bumped default to `15.0` for a safe margin above the 10s minimum.

## Bug 2: Non-existent model `gemini-3-flash` in provider list

The `DEFAULT_PROVIDERS` list included `gemini-3-flash`, which does not exist in the Gemini API. Verified by calling [`client.models.list()`](https://ai.google.dev/gemini-api/docs/models) against the live API — the model is not returned. The correct name is `gemini-3-flash-preview` (which was already in the list).

**Fix:** Removed the `gemini-3-flash` entry.

## Bug 3: 400/404 errors blocked the entire failover chain

`_is_retryable()` returned `False` for HTTP 400 (`INVALID_ARGUMENT`) and had no explicit handling for 404 (`NOT_FOUND`). This meant that if a model returned either error, the failover chain stopped immediately instead of trying the next model.

This is incorrect because:
- 400 from a timeout misconfiguration should not prevent trying other models
- 404 from a non-existent model should definitely try the next one

**Fix:** Made both 400 and 404 retryable so the failover chain works as intended.

## Bug 4: `response.content` returned as list crashes `.strip()`

Gemini 3 series models return `response.content` as a list of content blocks (not a plain string). `BaseAgent._run_llm()` passed this directly to `_parse_json_value()`, which called `.strip()` on it, crashing with:

```
AttributeError: 'list' object has no attribute 'strip'
```

**Source:** [LangChain Google GenAI docs](https://python.langchain.com/docs/integrations/chat/google_generative_ai/) — "Gemini 3 series models return a list of content blocks… Use `.text` to get string content." Gemini 2.5 and earlier return a plain string for `.content`.

**Fix:** Added type check in `_run_llm()` to join list parts into a string before returning. Handles dict parts, object parts (with `.text` attribute), and normalizes return to `str` unconditionally.

## Data

One MP (Jagadish Shettar) had family background enriched during testing. Data verified against [public sources](https://starsunfolded.com/jagadish-shettar/).

## Test plan

- [x] All 25 existing unit tests pass (`pytest tests/unit/config/ -v`)
- [x] Ran `run_politician_agent.py --type MP --limit 30` — 0 failures (vs 100% failure before)
- [x] Verified `gemini-2.5-flash` calls succeed end-to-end with enriched data written to `mp.json`
- [x] Addressed all 4 Copilot review comments