### PR TITLE
fix: correct status enum mismatch in elections-only fallback prompt

### DIFF
--- a/app/prompts/politician_prompts.py
+++ b/app/prompts/politician_prompts.py
@@ -50,7 +50,7 @@ class PoliticianPrompts:
             "You are extracting ONLY the election history for this politician.\n"
             "Return ONLY a valid JSON array. Each item format:\n"
             '[{ "year": 2024, "type": "MP|MLA", "state": "string", "constituency": "string", '
-            '"party": "string", "status": "WINNER|LOSER|INCUMBENT" }]\n'
+            '"party": "string", "status": "WON|LOST|CONTESTED" }]\n'
             f"Politician: {name}\nType: {ptype}\nState: {state}\nConstituency: {constituency}\n"
             "If unknown, return []"
         )


### PR DESCRIPTION
### What does this PR do?                                                                                                               
                                                                                                                                         
  Fixes enum mismatch in the `political_background_elections_only` fallback prompt. The LLM returned valid election data but Pydantic rejected it every time because the prompt asked for wrong status values.    

  ### Type of change

  - [x] Bug fix

  ### Scope

  - `app/prompts/politician_prompts.py` — single line fix

  ### Checklist

  - [x] I have **not** committed `.env`, API keys, or any secrets
  - [x] I have **not** committed `app/database/cache.db`
  - [x] I have reviewed the diff and it only contains intended changes