### PR TITLE
Fix auth flow: user sync to Postgres, API paths & DB init (Vibe Kanban)

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,85 +1,58 @@
 """
 Database configuration for Rajniti application.
 
-Simple PostgreSQL setup without any schema definitions yet.
+Delegates to the canonical app.database package for engine/session/Base
+so there is a single source of truth for all DB operations.
 """
 
 import logging
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import declarative_base, sessionmaker
 
 from app.database.config import get_database_url
 
 logger = logging.getLogger(__name__)
 
-# SQLAlchemy base for future models
-Base = declarative_base()
-
-# Global engine and session factory (used for simple setup)
-# Note: In production, consider using Flask-SQLAlchemy or similar
-# for better integration with Flask's application context
-engine = None
-SessionLocal = None
-
 
 def init_db(app=None):
     """
-    Initialize database connection.
+    Initialize database connection and create tables.
+
+    Delegates to app.database.session which owns the engine, SessionLocal,
+    and the Base that all models inherit from.
 
     Args:
-        app: Flask application instance (optional)
+        app: Flask application instance (optional, reserved for future use)
     """
-    global engine, SessionLocal
-
-    # Get database URL from unified config (works with local PostgreSQL or Supabase)
     database_url = get_database_url(required=False)
     if not database_url:
         logger.warning("DATABASE_URL not set. Database will not be initialized.")
         return False
 
     try:
-        # Create engine
-        engine = create_engine(
-            database_url,
-            pool_pre_ping=True,  # Verify connections before using
-            echo=False,  # Set to True for SQL query logging
-        )
+        from app.database.session import init_db as create_tables
+        from app.database.session import init_engine
 
-        # Create session factory
-        SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        db_engine = init_engine()
+        if db_engine is None:
+            logger.error("Failed to create database engine.")
+            return False
 
-        # Test connection
-        with engine.connect() as conn:
+        with db_engine.connect() as conn:
             conn.execute(text("SELECT 1"))
 
-        logger.info("Database connection established successfully")
+        create_tables()
+
+        logger.info("Database connection established and tables ensured")
         return True
 
     except SQLAlchemyError as e:
-        logger.error(f"Database error during initialization: {str(e)}")
+        logger.error(f"Database error during initialization: {e}")
         return False
     except Exception as e:
-        logger.error(f"Unexpected error initializing database: {str(e)}")
+        logger.error(f"Unexpected error initializing database: {e}")
         return False
-
-
-def get_db():
-    """
-    Get a database session.
-
-    Yields:
-        Session: SQLAlchemy database session
-    """
-    if SessionLocal is None:
-        raise RuntimeError("Database not initialized. Call init_db() first.")
-
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def check_db_health():
@@ -89,6 +62,8 @@ def check_db_health():
     Returns:
         bool: True if database is healthy, False otherwise
     """
+    from app.database.session import engine
+
     if engine is None:
         return False
 
@@ -97,8 +72,8 @@ def check_db_health():
             conn.execute(text("SELECT 1"))
         return True
     except SQLAlchemyError as e:
-        logger.error(f"Database health check failed: {str(e)}")
+        logger.error(f"Database health check failed: {e}")
         return False
     except Exception as e:
-        logger.error(f"Unexpected error during health check: {str(e)}")
+        logger.error(f"Unexpected error during health check: {e}")
         return False

--- a/app/database/session.py
+++ b/app/database/session.py
@@ -29,7 +29,9 @@ def init_engine():
     try:
         database_url = get_database_url()
     except ValueError:
-        # Database is optional for most workflows; only required for user persistence.
+        return None
+
+    if not database_url:
         return None
 
     engine = create_engine(

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,7 +7,7 @@ GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # Backend API URL
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
 
 # Google Analytics 4 — leave empty to disable tracking
 NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/frontend/__tests__/lib/api/user.test.ts
+++ b/frontend/__tests__/lib/api/user.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for userService API functions.
+ *
+ * Verifies URL paths, HTTP methods, request bodies, and error handling.
+ * The env var must be set before the module is required (imports are hoisted).
+ */
+
+const API_BASE = 'http://localhost:8000/api/v1'
+
+let userService: typeof import('@/lib/api/user')['userService']
+let mockFetch: jest.Mock
+
+beforeAll(() => {
+    process.env.NEXT_PUBLIC_API_URL = API_BASE
+    jest.resetModules()
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    userService = require('@/lib/api/user').userService
+    mockFetch = global.fetch as jest.Mock
+})
+
+beforeEach(() => {
+    mockFetch.mockReset()
+})
+
+function okResponse(data: unknown) {
+    return { ok: true, status: 200, json: () => Promise.resolve(data) }
+}
+
+function errorResponse(body: unknown, status = 500) {
+    return { ok: false, status, statusText: 'Error', json: () => Promise.resolve(body) }
+}
+
+// ---------------------------------------------------------------------------
+// syncUser
+// ---------------------------------------------------------------------------
+describe('userService.syncUser', () => {
+    it('calls the /api/v1/users/sync endpoint', async () => {
+        mockFetch.mockResolvedValueOnce(okResponse({ success: true }))
+
+        await userService.syncUser({ id: 'u1', email: 'a@b.com' })
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            `${API_BASE}/users/sync`,
+            expect.any(Object),
+        )
+    })
+
+    it('sends POST with JSON content-type and serialized body', async () => {
+        const userData = { id: 'u1', email: 'a@b.com', name: 'Test' }
+        mockFetch.mockResolvedValueOnce(okResponse({ success: true, data: userData }))
+
+        await userService.syncUser(userData)
+
+        const [, opts] = mockFetch.mock.calls[0]
+        expect(opts.method).toBe('POST')
+        expect(opts.headers['Content-Type']).toBe('application/json')
+        expect(JSON.parse(opts.body)).toEqual(userData)
+    })
+
+    it('returns parsed JSON on success', async () => {
+        const payload = { success: true, data: { id: 'u1' } }
+        mockFetch.mockResolvedValueOnce(okResponse(payload))
+
+        const result = await userService.syncUser({ id: 'u1', email: 'a@b.com' })
+        expect(result).toEqual(payload)
+    })
+
+    it('throws when response is not ok', async () => {
+        mockFetch.mockResolvedValueOnce(errorResponse({}, 500))
+
+        await expect(
+            userService.syncUser({ id: 'u1', email: 'a@b.com' }),
+        ).rejects.toThrow(/Failed to sync user/)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// updateUser
+// ---------------------------------------------------------------------------
+describe('userService.updateUser', () => {
+    it('calls /users/{userId} with PATCH', async () => {
+        mockFetch.mockResolvedValueOnce(okResponse({ success: true }))
+
+        await userService.updateUser('user-42', { name: 'Updated' })
+
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/users/user-42`)
+        expect(opts.method).toBe('PATCH')
+    })
+
+    it('sends political_ideology (not political_interest)', async () => {
+        const data = {
+            username: 'raj',
+            political_ideology: 'Centrist',
+            onboarding_completed: true as const,
+        }
+        mockFetch.mockResolvedValueOnce(okResponse({ success: true, data }))
+
+        await userService.updateUser('u1', data)
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+        expect(body).toHaveProperty('political_ideology', 'Centrist')
+        expect(body).not.toHaveProperty('political_interest')
+    })
+
+    it('returns parsed JSON on success', async () => {
+        const payload = { success: true, data: { id: 'u1', name: 'New' } }
+        mockFetch.mockResolvedValueOnce(okResponse(payload))
+
+        const result = await userService.updateUser('u1', { name: 'New' })
+        expect(result).toEqual(payload)
+    })
+
+    it('throws with backend error message on failure', async () => {
+        mockFetch.mockResolvedValueOnce(
+            errorResponse({ error: 'Username is already taken' }, 400),
+        )
+
+        await expect(
+            userService.updateUser('u1', { username: 'taken' }),
+        ).rejects.toThrow('Username is already taken')
+    })
+})
+
+// ---------------------------------------------------------------------------
+// checkUsername
+// ---------------------------------------------------------------------------
+describe('userService.checkUsername', () => {
+    it('calls /users/check-username with POST', async () => {
+        mockFetch.mockResolvedValueOnce(okResponse({ available: true }))
+
+        await userService.checkUsername('testuser')
+
+        const [url, opts] = mockFetch.mock.calls[0]
+        expect(url).toBe(`${API_BASE}/users/check-username`)
+        expect(opts.method).toBe('POST')
+    })
+
+    it('sends username and optional user_id in body', async () => {
+        mockFetch.mockResolvedValueOnce(okResponse({ available: true }))
+
+        await userService.checkUsername('raj', 'user-99')
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+        expect(body).toEqual({ username: 'raj', user_id: 'user-99' })
+    })
+
+    it('omits user_id when not provided', async () => {
+        mockFetch.mockResolvedValueOnce(okResponse({ available: true }))
+
+        await userService.checkUsername('raj')
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+        expect(body.username).toBe('raj')
+        expect(body.user_id).toBeUndefined()
+    })
+
+    it('returns availability result', async () => {
+        mockFetch.mockResolvedValueOnce(okResponse({ available: false }))
+
+        const result = await userService.checkUsername('taken')
+        expect(result).toEqual({ available: false })
+    })
+
+    it('throws when response is not ok', async () => {
+        mockFetch.mockResolvedValueOnce(errorResponse({}, 500))
+
+        await expect(userService.checkUsername('test')).rejects.toThrow(
+            'Failed to check username',
+        )
+    })
+})

--- a/frontend/__tests__/lib/user.test.ts
+++ b/frontend/__tests__/lib/user.test.ts
@@ -197,22 +197,24 @@ describe('userService', () => {
 })
 
 describe('userService API URL', () => {
-  beforeEach(() => {
-    mockFetch.mockReset()
-  })
-
-  it('should use correct API base URL', async () => {
-    mockFetch.mockResolvedValueOnce({
+  it('should use correct API base URL with /api/v1 prefix', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000/api/v1'
+    jest.resetModules()
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const freshService = require('@/lib/api/user').userService
+    const freshFetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ success: true }),
     })
+    global.fetch = freshFetch
 
-    await userService.checkUsername('test')
+    await freshService.checkUsername('test')
 
-    // Should use the API URL from environment or default
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(freshFetch).toHaveBeenCalledWith(
       expect.stringMatching(/\/api\/v1\/users\/check-username$/),
-      expect.any(Object)
+      expect.any(Object),
     )
+
+    global.fetch = mockFetch
   })
 })

--- a/frontend/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/app/api/auth/[...nextauth]/route.ts
@@ -15,16 +15,12 @@ const authOptions: NextAuthOptions = {
             if (account && profile) {
                 token.accessToken = account.access_token
                 token.userId = profile.sub
-                console.log("profile", profile)
 
-                // Sync user with backend when they sign in
                 try {
                     const profileData = profile as {
                         picture?: string
                         image?: string
                     }
-                    console.log("profileData", profileData)
-                    // Use the userService helper
                     const data = await userService.syncUser({
                         id: profile.sub,
                         email: profile.email,
@@ -32,7 +28,6 @@ const authOptions: NextAuthOptions = {
                         profile_picture:
                             profileData.picture || profileData.image
                     })
-                    console.log("data", data)
 
                     // Store onboarding status in token
                     token.onboardingCompleted =

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -31,7 +31,7 @@ function OnboardingContent() {
   const [usernameValid, setUsernameValid] = useState(false)
   
   const [formData, setFormData] = useState({
-    political_interest: '',
+    political_ideology: '',
     username: ''
   })
 
@@ -45,7 +45,7 @@ function OnboardingContent() {
   const canProceedToNextStep = () => {
     switch (step) {
       case 1:
-        return formData.political_interest !== ''
+        return formData.political_ideology !== ''
       case 2:
         return formData.username !== '' && usernameValid
       default:
@@ -63,12 +63,12 @@ function OnboardingContent() {
       
       // Call backend API using the generic update endpoint
       await userService.updateUser(session.user.id, {
-        political_interest: formData.political_interest,
+        political_ideology: formData.political_ideology,
         username: formData.username,
         onboarding_completed: true
       })
 
-      trackEvent('onboarding_complete', { political_interest: formData.political_interest })
+      trackEvent('onboarding_complete', { political_ideology: formData.political_ideology })
       await update({ onboardingCompleted: true })
       router.push('/dashboard')
     } catch (error) {
@@ -127,8 +127,8 @@ function OnboardingContent() {
                 transition={{ duration: 0.3 }}
               >
                 <PoliticalInclinationStep
-                  value={formData.political_interest}
-                  onChange={(value) => updateField('political_interest', value)}
+                  value={formData.political_ideology}
+                  onChange={(value) => updateField('political_ideology', value)}
                 />
               </motion.div>
             )}

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Sign-in page', () => {
+    test('renders the sign-in page with Google button', async ({ page }) => {
+        await page.goto('/auth/signin')
+
+        await expect(page.getByRole('heading', { name: /welcome to rajniti/i })).toBeVisible()
+        await expect(page.getByRole('button', { name: /continue with google/i })).toBeVisible()
+        await expect(page.getByText(/sign in to access your personalized/i)).toBeVisible()
+    })
+
+    test('has a link back to home', async ({ page }) => {
+        await page.goto('/auth/signin')
+
+        const backLink = page.getByRole('link', { name: /back to home/i })
+        await expect(backLink).toBeVisible()
+        await expect(backLink).toHaveAttribute('href', '/')
+    })
+
+    test('Google button triggers NextAuth sign-in flow', async ({ page }) => {
+        await page.goto('/auth/signin')
+
+        const [request] = await Promise.all([
+            page.waitForRequest((req) =>
+                req.url().includes('/api/auth/signin/google') ||
+                req.url().includes('accounts.google.com'),
+            ),
+            page.getByRole('button', { name: /continue with google/i }).click(),
+        ]).catch(() => [null])
+
+        // Either redirects to Google or hits the NextAuth signin endpoint
+        // Both indicate the OAuth flow initiated correctly
+        if (request) {
+            expect(request.url()).toMatch(/google|api\/auth/)
+        }
+    })
+})
+
+test.describe('Unauthenticated navigation', () => {
+    test('navbar shows Sign In button when not logged in', async ({ page }) => {
+        await page.goto('/')
+
+        await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible()
+    })
+
+    test('dashboard redirects unauthenticated users to sign-in', async ({ page }) => {
+        await page.goto('/dashboard')
+
+        // Should either redirect to sign-in or show sign-in prompt
+        await page.waitForURL(/\/(auth\/signin|dashboard)/, { timeout: 5000 })
+    })
+})
+
+test.describe('API health (backend connectivity)', () => {
+    test('backend health endpoint responds when running', async ({ request }) => {
+        const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
+
+        try {
+            const response = await request.get(`${backendUrl}/health`)
+            // If backend is running, should return 200
+            if (response.ok()) {
+                const body = await response.json()
+                expect(body.success).toBe(true)
+                expect(body).toHaveProperty('database')
+            }
+        } catch {
+            // Backend not running is acceptable in CI without Docker
+            test.skip()
+        }
+    })
+
+    test('user sync endpoint accepts POST (backend running)', async ({ request }) => {
+        const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1'
+
+        try {
+            const response = await request.post(`${backendUrl}/users/sync`, {
+                data: {
+                    id: 'e2e-test-user',
+                    email: 'e2e@test.com',
+                    name: 'E2E Test',
+                },
+            })
+
+            // Should get 200 (user created) or 500 (no DB) - not 404
+            expect(response.status()).not.toBe(404)
+        } catch {
+            test.skip()
+        }
+    })
+})
+
+test.describe('Onboarding page (unauthenticated)', () => {
+    test('onboarding page loads and shows step 1', async ({ page }) => {
+        await page.goto('/onboarding')
+
+        await expect(page.getByText(/step 1 of 2/i)).toBeVisible()
+        await expect(page.getByText(/political inclination/i).first()).toBeVisible()
+    })
+
+    test('onboarding shows all political ideology options', async ({ page }) => {
+        await page.goto('/onboarding')
+
+        const ideologies = ['Rightist', 'Leftist', 'Communist', 'Centrist', 'Libertarian', 'Neutral']
+        for (const ideology of ideologies) {
+            await expect(page.getByRole('button', { name: new RegExp(ideology, 'i') })).toBeVisible()
+        }
+    })
+
+    test('continue button is disabled until an option is selected', async ({ page }) => {
+        await page.goto('/onboarding')
+
+        const continueBtn = page.getByRole('button', { name: /continue/i })
+        await expect(continueBtn).toBeDisabled()
+
+        // Select an option
+        await page.getByRole('button', { name: /centrist/i }).click()
+        await expect(continueBtn).toBeEnabled()
+    })
+
+    test('navigating to step 2 shows username input', async ({ page }) => {
+        await page.goto('/onboarding')
+
+        await page.getByRole('button', { name: /centrist/i }).click()
+        await page.getByRole('button', { name: /continue/i }).click()
+
+        await expect(page.getByText(/step 2 of 2/i)).toBeVisible()
+        await expect(page.getByText(/choose your username/i)).toBeVisible()
+        await expect(page.getByPlaceholder(/johndoe/i)).toBeVisible()
+    })
+
+    test('skip link is present on onboarding', async ({ page }) => {
+        await page.goto('/onboarding')
+
+        await expect(page.getByRole('button', { name: /skip for now/i })).toBeVisible()
+    })
+})

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -67,6 +67,7 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/.next/',
+    '<rootDir>/e2e/',
   ],
   
   // Module file extensions

--- a/frontend/lib/analytics/events.ts
+++ b/frontend/lib/analytics/events.ts
@@ -70,7 +70,7 @@ export type AnalyticsEventMap = {
   }
 
   onboarding_complete: {
-    political_interest: string
+    political_ideology: string
   }
 
   onboarding_skip: {

--- a/frontend/lib/api/user.ts
+++ b/frontend/lib/api/user.ts
@@ -7,7 +7,7 @@ export interface UserData {
     name?: string
     profile_picture?: string
     username?: string
-    political_interest?: string
+    political_ideology?: string
     onboarding_completed?: boolean
     [key: string]: string | boolean | undefined
 }
@@ -18,13 +18,6 @@ export const userService = {
      * Used during authentication
      */
     async syncUser(userData: UserData) {
-        console.log("userData", `${API_BASE_URL}/users/sync`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json"
-            },
-            body: JSON.stringify(userData)
-        })
         const response = await fetch(`${API_BASE_URL}/users/sync`, {
             method: "POST",
             headers: {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,11 @@
+import path from "path"
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
+    // Pin project root for Turbopack (avoids multi-lockfile workspace confusion)
+    turbopack: {
+        root: path.join(__dirname),
+    },
     // Environment variables
     env: {
         NEXT_PUBLIC_API_URL:

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
     // Environment variables
     env: {
         NEXT_PUBLIC_API_URL:
-            process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+            process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1"
     },
 
     // Image optimization

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "19.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^16.3.0",
@@ -83,7 +84,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1961,6 +1961,22 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2377,7 +2393,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2556,7 +2573,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2567,7 +2583,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2648,7 +2663,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3182,7 +3196,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3727,7 +3740,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4309,7 +4321,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -4632,7 +4645,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4818,7 +4830,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7963,6 +7974,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8838,6 +8850,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8882,7 +8940,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
       "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -8922,6 +8979,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8937,6 +8995,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9050,7 +9109,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9060,7 +9118,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9073,7 +9130,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -10002,7 +10060,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10234,7 +10291,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10750,7 +10806,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react-dom": "19.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.3.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+    testDir: './e2e',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: 'html',
+    use: {
+        baseURL: 'http://localhost:3000',
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+    webServer: {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 30_000,
+    },
+})

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/tests/unit/database/test_db_init.py
+++ b/tests/unit/database/test_db_init.py
@@ -1,0 +1,253 @@
+"""
+Unit tests for database initialization and session management.
+Tests verify the fixes for:
+- Empty DATABASE_URL handling in init_engine()
+- Consolidated DB init in app.core.database
+- get_db_session() error handling
+"""
+
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+# Mock chromadb before app imports
+sys.modules["chromadb"] = MagicMock()
+sys.modules["chromadb.config"] = MagicMock()
+
+
+@pytest.mark.unit
+class TestInitEngine:
+    """Tests for app.database.session.init_engine()."""
+
+    def test_returns_none_when_database_url_empty(self):
+        """init_engine returns None when DATABASE_URL is empty."""
+        import app.database.session as session_mod
+
+        session_mod.engine = None
+        session_mod.SessionLocal = None
+        try:
+            with patch("app.database.session.get_database_url", return_value=""):
+                result = session_mod.init_engine()
+            assert result is None
+            assert session_mod.engine is None
+        finally:
+            session_mod.engine = None
+            session_mod.SessionLocal = None
+
+    def test_returns_none_when_database_url_raises(self):
+        """init_engine returns None when get_database_url raises ValueError."""
+        import app.database.session as session_mod
+
+        session_mod.engine = None
+        session_mod.SessionLocal = None
+        try:
+            with patch(
+                "app.database.session.get_database_url", side_effect=ValueError("no url")
+            ):
+                result = session_mod.init_engine()
+            assert result is None
+            assert session_mod.engine is None
+        finally:
+            session_mod.engine = None
+            session_mod.SessionLocal = None
+
+    def test_creates_engine_with_valid_url(self):
+        """init_engine creates engine and SessionLocal when URL is valid."""
+        import app.database.session as session_mod
+
+        session_mod.engine = None
+        session_mod.SessionLocal = None
+        mock_engine = MagicMock()
+        mock_session_factory = MagicMock()
+        try:
+            with patch(
+                "app.database.session.get_database_url",
+                return_value="sqlite:///:memory:",
+            ), patch(
+                "app.database.session.create_engine",
+                return_value=mock_engine,
+            ), patch(
+                "app.database.session.sessionmaker",
+                return_value=mock_session_factory,
+            ):
+                result = session_mod.init_engine()
+            assert result is mock_engine
+            assert session_mod.engine is mock_engine
+            assert session_mod.SessionLocal is mock_session_factory
+        finally:
+            session_mod.engine = None
+            session_mod.SessionLocal = None
+
+    def test_idempotent_when_already_initialized(self):
+        """init_engine returns existing engine without calling get_database_url."""
+        import app.database.session as session_mod
+
+        mock_engine = MagicMock()
+        mock_session_factory = MagicMock()
+        session_mod.engine = mock_engine
+        session_mod.SessionLocal = mock_session_factory
+        try:
+            with patch(
+                "app.database.session.get_database_url"
+            ) as mock_get_url:
+                result = session_mod.init_engine()
+            assert result is mock_engine
+            mock_get_url.assert_not_called()
+        finally:
+            session_mod.engine = None
+            session_mod.SessionLocal = None
+
+
+@pytest.mark.unit
+class TestGetDbSession:
+    """Tests for app.database.base.get_db_session()."""
+
+    def test_raises_when_no_session_factory(self):
+        """get_db_session raises RuntimeError when SessionLocal is None."""
+        import app.database.session as session_mod
+        from app.database.base import get_db_session
+
+        session_mod.engine = None
+        session_mod.SessionLocal = None
+        try:
+            with patch("app.database.session.init_engine"):
+                with pytest.raises(RuntimeError) as exc_info:
+                    with get_db_session():
+                        pass
+            assert "session factory not initialized" in str(exc_info.value)
+        finally:
+            session_mod.engine = None
+            session_mod.SessionLocal = None
+
+    def test_commits_on_success(self):
+        """get_db_session commits when context exits normally."""
+        import app.database.session as session_mod
+        from app.database.base import get_db_session
+
+        mock_session = MagicMock()
+        mock_session_factory = MagicMock(return_value=mock_session)
+        session_mod.engine = MagicMock()
+        session_mod.SessionLocal = mock_session_factory
+        try:
+            with get_db_session() as session:
+                assert session is mock_session
+            mock_session.commit.assert_called_once()
+            mock_session.close.assert_called_once()
+        finally:
+            session_mod.engine = None
+            session_mod.SessionLocal = None
+
+    def test_rollback_on_error(self):
+        """get_db_session rolls back and does not commit when exception raised."""
+        import app.database.session as session_mod
+        from app.database.base import get_db_session
+
+        mock_session = MagicMock()
+        mock_session_factory = MagicMock(return_value=mock_session)
+        session_mod.engine = MagicMock()
+        session_mod.SessionLocal = mock_session_factory
+        try:
+            with pytest.raises(ValueError):
+                with get_db_session() as session:
+                    raise ValueError("test error")
+            mock_session.rollback.assert_called_once()
+            mock_session.commit.assert_not_called()
+            mock_session.close.assert_called_once()
+        finally:
+            session_mod.engine = None
+            session_mod.SessionLocal = None
+
+
+@pytest.mark.unit
+class TestCoreDatabaseInitDb:
+    """Tests for app.core.database.init_db()."""
+
+    def test_returns_false_when_no_database_url(self):
+        """init_db returns False when DATABASE_URL is empty."""
+        import app.core.database as core_db
+
+        with patch("app.core.database.get_database_url", return_value=""):
+            result = core_db.init_db()
+        assert result is False
+
+    def test_returns_true_on_success(self):
+        """init_db returns True when connection and table creation succeed."""
+        import app.core.database as core_db
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = Mock(return_value=mock_conn)
+        mock_conn.__exit__ = Mock(return_value=False)
+        mock_engine.connect.return_value = mock_conn
+
+        with patch(
+            "app.core.database.get_database_url",
+            return_value="postgresql://user:pass@localhost/db",
+        ), patch(
+            "app.database.session.init_engine",
+            return_value=mock_engine,
+        ), patch(
+            "app.database.session.init_db",
+        ):
+            result = core_db.init_db()
+        assert result is True
+
+    def test_returns_false_on_connection_error(self):
+        """init_db returns False when engine.connect raises."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        import app.core.database as core_db
+
+        mock_engine = MagicMock()
+        mock_engine.connect.side_effect = SQLAlchemyError("connection failed")
+
+        with patch(
+            "app.core.database.get_database_url",
+            return_value="postgresql://user:pass@localhost/db",
+        ), patch(
+            "app.database.session.init_engine",
+            return_value=mock_engine,
+        ):
+            result = core_db.init_db()
+        assert result is False
+
+
+@pytest.mark.unit
+class TestCheckDbHealth:
+    """Tests for app.core.database.check_db_health()."""
+
+    def test_returns_false_when_engine_none(self):
+        """check_db_health returns False when engine is None."""
+        import app.core.database as core_db
+
+        with patch("app.database.session.engine", None):
+            result = core_db.check_db_health()
+        assert result is False
+
+    def test_returns_true_when_healthy(self):
+        """check_db_health returns True when connection succeeds."""
+        import app.core.database as core_db
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = Mock(return_value=mock_conn)
+        mock_conn.__exit__ = Mock(return_value=False)
+        mock_engine.connect.return_value = mock_conn
+
+        with patch("app.database.session.engine", mock_engine):
+            result = core_db.check_db_health()
+        assert result is True
+
+    def test_returns_false_on_error(self):
+        """check_db_health returns False when connect raises SQLAlchemyError."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        import app.core.database as core_db
+
+        mock_engine = MagicMock()
+        mock_engine.connect.side_effect = SQLAlchemyError("connection failed")
+
+        with patch("app.database.session.engine", mock_engine):
+            result = core_db.check_db_health()
+        assert result is False


### PR DESCRIPTION
## What changed

This PR fixes the auth system so new users are correctly synced to Postgres and onboarding data is persisted. Previously, users could sign in with Google but were never stored in the database.

### Bug fixes

1. **API URL path mismatch (critical)**  
   The frontend was calling `http://localhost:8000/users/sync` while the Flask backend serves user routes at `/api/v1/users/sync`. Every sync request returned 404, so no users were created.
   - **Fix:** Set `NEXT_PUBLIC_API_URL` default to include `/api/v1` in `next.config.ts` and `.env.example`.

2. **Users table never created (critical)**  
   `app/core/database.py` used its own `Base` class and never created tables. The referenced migration module did not exist, so the `users` table was never created.
   - **Fix:** Refactored `app.core.database` to delegate to `app.database.session`, which owns the engine, `Base`, and User model. Table creation now runs correctly on app startup.

3. **Onboarding political preference not saved (moderate)**  
   The frontend sent `political_interest` but the backend and User model expect `political_ideology`. The value was silently dropped.
   - **Fix:** Updated `onboarding/page.tsx` and `lib/api/user.ts` to use `political_ideology`.

4. **Empty DATABASE_URL handling (minor)**  
   Passing an empty string to `create_engine()` caused unclear errors.
   - **Fix:** Added an early return in `init_engine()` when `DATABASE_URL` is missing or empty.

### Implementation details

- **Single DB system:** All DB operations now go through `app.database` (engine, SessionLocal, Base). Health checks and user persistence use the same setup.
- **Debug logs removed** from the NextAuth route and user API service.

### Tests added

- **Backend:** `tests/unit/database/test_db_init.py` — 13 tests for `init_engine`, `get_db_session`, `init_db`, and `check_db_health`.
- **Frontend:** `__tests__/lib/api/user.test.ts` — 13 tests for `syncUser`, `updateUser`, `checkUsername` (URLs, methods, field names).
- **E2E:** `e2e/auth.spec.ts` — 12 Playwright tests for sign-in page, unauthenticated flows, backend connectivity, and onboarding.
- Playwright config added; Jest updated to ignore `e2e/`.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)