### PR TITLE
Fix party filtering logic and implement missing party endpoint

### DIFF
--- a/app/services/politician_service.py
+++ b/app/services/politician_service.py
@@ -138,6 +138,33 @@ class PoliticianService:
 
         return self._attach_performance(p) if p else None
 
+    def get_by_party(self, party: str, election_type: Optional[str] = None):
+        self._ensure_slugs()
+        party_l = party.lower()
+
+        data = (
+            self._load(election_type)
+            if election_type
+            else self._load("MP") + self._load("MLA")
+        )
+        self._attach_slugs_to_records(data)
+
+        results = []
+
+        for p in data:
+            elections = (p.get("political_background") or {}).get("elections") or []
+            if not elections:
+                continue
+
+            # ✅ latest election ONLY
+            latest = max(elections, key=lambda x: x.get("year", 0))
+            current_party = (latest.get("party") or "").lower()
+
+            if current_party == party_l:
+                results.append(self._attach_performance(p))
+
+        return results
+
     def search(
         self,
         query: str,
@@ -173,10 +200,16 @@ class PoliticianService:
 
             if party_l is not None:
                 elections = (p.get("political_background") or {}).get("elections") or []
-                if not any(
-                    (e.get("party") or "").lower() == party_l for e in elections
-                ):
-                    continue
+                if party_l is not None:
+                    elections = (p.get("political_background") or {}).get("elections") or []
+                    if not elections:
+                        continue
+
+                    latest = max(elections, key=lambda x: x.get("year", 0))
+                    latest_party = (latest.get("party") or "").lower()
+
+                    if latest_party != party_l:
+                        continue
 
             results.append(self._attach_performance(p))
 


### PR DESCRIPTION
### Description:

This PR addresses issues with party-based filtering and a missing backend implementation.
closes #151 

#### Changes:

* Implemented `get_by_party` method in `PoliticianService` (previously missing, causing API failure)
* Updated filtering logic to use the **latest election** instead of checking any past party affiliation
* Ensured consistency between `/party` and `/search` endpoints

#### Problem:

* `/api/v1/politicians/party/<party>` endpoint was failing due to missing method
* Filtering logic incorrectly included politicians based on past party affiliations

#### Solution:

* Extract latest election using `max(elections, key=lambda x: x.get("year", 0))`
* Filter based on current party only

#### Notes:

* API expects full party names (e.g., "Indian National Congress") as stored in dataset

#### Testing:

* Verified `/api/v1/politicians/party/Indian National Congress` returns correct results
* Verified `/api/v1/politicians/search?q=&party=Indian National Congress` works correctly
