### PR TITLE
feat(#219): "% facts verified" badge in politician hero

### DIFF
--- a/app/schemas/politician.py
+++ b/app/schemas/politician.py
@@ -152,6 +152,10 @@ class Politician(BaseModel):
         None,
         description="Optional audit metadata: issues, mismatches, last_run",
     )
+    facts_verified_pct: Optional[int] = Field(
+        None,
+        description="0-100 integer: percentage of non-null fields backed by a citation. Computed server-side.",
+    )
 
     class Config:
         json_schema_extra = {

--- a/app/services/politician_service.py
+++ b/app/services/politician_service.py
@@ -65,6 +65,69 @@ class PoliticianService:
         p["updated_at"] = p.get("lastUpdated")
         return p
 
+    # ---------- FACTS VERIFIED ----------
+    def _compute_facts_verified_pct(self, p: Dict[str, Any]) -> int:
+        """Return 0-100 integer: (cited fields) / (total non-null checkable fields)."""
+        total = 0
+        cited = 0
+
+        pb = p.get("political_background") or {}
+
+        for election in pb.get("elections") or []:
+            total += 1
+            if election.get("citation"):
+                cited += 1
+
+        if pb.get("summary"):
+            total += 1
+            if pb.get("summary_citation"):
+                cited += 1
+
+        for edu in p.get("education") or []:
+            total += 1
+            if edu.get("citation"):
+                cited += 1
+
+        for member in p.get("family_background") or []:
+            total += 1
+            if member.get("citation"):
+                cited += 1
+
+        for crime in p.get("criminal_records") or []:
+            total += 1
+            if crime.get("citation"):
+                cited += 1
+
+        contact = p.get("contact") or {}
+        contact_citations = p.get("contact_citations") or {}
+        for field in ("email", "phone", "address"):
+            if contact.get(field):
+                total += 1
+                if contact_citations.get(field):
+                    cited += 1
+
+        social = p.get("social_media") or {}
+        social_citations = p.get("social_media_citations") or {}
+        for field in ("twitter", "facebook", "instagram", "linkedin", "youtube", "website"):
+            if social.get(field):
+                total += 1
+                if social_citations.get(field):
+                    cited += 1
+
+        perf_citations = p.get("performance_citations") or {}
+        for field in ("attendance", "questions", "debates"):
+            if perf_citations.get(field):
+                total += 1
+                cited += 1
+
+        if total == 0:
+            return 0
+        return round((cited / total) * 100)
+
+    def _attach_verification(self, p: Dict[str, Any]) -> Dict[str, Any]:
+        p["facts_verified_pct"] = self._compute_facts_verified_pct(p)
+        return p
+
     # ---------- SLUG ----------
     def _ensure_slugs(self) -> None:
         if self._slugs_ensured:
@@ -125,21 +188,21 @@ class PoliticianService:
         data = self._load(election_type)
         self._attach_slugs_to_records(data)
 
-        return [self._attach_metadata(self._attach_performance(p)) for p in data]
+        return [self._attach_metadata(self._attach_verification(self._attach_performance(p))) for p in data]
 
     def get_all_politicians(self) -> List[Dict[str, Any]]:
         self._ensure_slugs()
         data = self._load("MP") + self._load("MLA")
         self._attach_slugs_to_records(data)
 
-        return [self._attach_metadata(self._attach_performance(p)) for p in data]
+        return [self._attach_metadata(self._attach_verification(self._attach_performance(p))) for p in data]
 
     def get_by_id(self, politician_id: str) -> Optional[Dict[str, Any]]:
         self._ensure_slugs()
         pid = str(politician_id).strip()
         p = self._by_id.get(pid) or self._by_id.get(pid.lower())
 
-        return self._attach_metadata(self._attach_performance(p)) if p else None
+        return self._attach_metadata(self._attach_verification(self._attach_performance(p))) if p else None
 
     def get_by_slug(self, politician_slug: str) -> Optional[Dict[str, Any]]:
         self._ensure_slugs()
@@ -151,7 +214,7 @@ class PoliticianService:
             if short_match:
                 p = self._by_short_id.get(short_match.group(1).lower())
 
-        return self._attach_metadata(self._attach_performance(p)) if p else None
+        return self._attach_metadata(self._attach_verification(self._attach_performance(p))) if p else None
 
     def search(
         self,
@@ -193,7 +256,7 @@ class PoliticianService:
                 ):
                     continue
 
-            results.append(self._attach_metadata(self._attach_performance(p)))
+            results.append(self._attach_metadata(self._attach_verification(self._attach_performance(p))))
 
             if len(results) >= limit:
                 break
@@ -267,7 +330,7 @@ class PoliticianService:
         state_l = state.strip().lower()
 
         return [
-            self._attach_metadata(self._attach_performance(p))
+            self._attach_metadata(self._attach_verification(self._attach_performance(p)))
             for p in data
             if (p.get("state") or "").lower() == state_l
         ]
@@ -296,7 +359,7 @@ class PoliticianService:
             elections = (p.get("political_background") or {}).get("elections") or []
 
             if any((e.get("party") or "").lower() == party_l for e in elections):
-                results.append(self._attach_metadata(self._attach_performance(p)))
+                results.append(self._attach_metadata(self._attach_verification(self._attach_performance(p))))
 
         return results
 

--- a/frontend/app/politician/[id]/PoliticianPageClient.tsx
+++ b/frontend/app/politician/[id]/PoliticianPageClient.tsx
@@ -18,6 +18,7 @@ import {
   Phone,
   MapPin,
   Clock,
+  ShieldCheck,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { CitationLink } from "@/components/CitationLink";
@@ -1349,13 +1350,33 @@ export default function PoliticianPageClient({
                 {toTitleCase(p.constituency)} · {p.state} · {party}
               </p>
 
-              {/* Updated chip */}
-              {p.updated_at && formatUpdatedAt(p.updated_at) && (
-                <span className="mt-3 inline-flex items-center gap-1 text-xs text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded-full px-2.5 py-1">
-                  <Clock size={11} />
-                  {formatUpdatedAt(p.updated_at)}
-                </span>
-              )}
+              {/* Chips row: Updated + Verified */}
+              <div className="mt-3 flex flex-wrap gap-2">
+                {p.updated_at && formatUpdatedAt(p.updated_at) && (
+                  <span className="inline-flex items-center gap-1 text-xs text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-700 rounded-full px-2.5 py-1">
+                    <Clock size={11} />
+                    {formatUpdatedAt(p.updated_at)}
+                  </span>
+                )}
+                {p.facts_verified_pct != null && (
+                  <span
+                    className={`inline-flex items-center gap-1 text-xs font-semibold rounded-full px-2.5 py-1 ${
+                      p.facts_verified_pct === 0
+                        ? "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                        : p.facts_verified_pct >= 75
+                        ? "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300"
+                        : p.facts_verified_pct >= 60
+                        ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300"
+                        : "bg-red-100 text-red-600 dark:bg-red-900/40 dark:text-red-300"
+                    }`}
+                  >
+                    <ShieldCheck size={11} />
+                    {p.facts_verified_pct === 0
+                      ? "Unverified — help us source this"
+                      : `${p.facts_verified_pct}% verified`}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
 

--- a/frontend/types/politician.ts
+++ b/frontend/types/politician.ts
@@ -115,6 +115,8 @@ export interface Politician {
         Record<"attendance" | "questions" | "debates", Citation>
     > | null
     citation_audit?: Record<string, unknown> | null
+    /** 0-100: percentage of non-null fields backed by a citation. Computed server-side. */
+    facts_verified_pct?: number | null
 }
 
 /** Client-side computed stats */


### PR DESCRIPTION
<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="112:1-114:25;5132-5325"><strong>User story:</strong> As a voter deciding whether to trust this profile, I want a
single number telling me how much of it is independently sourced, so I can gauge
reliability at a glance.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="116:1-119:81;5327-5672"><strong>Metric:</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sourced_pct = (cited fields) ÷ (total non-null checkable fields)</code>, computed
server-side, returned on every profile response. "Cited" = the field carries a citation
object. (Future: weight by source independence/quality — self-citations shouldn't count
equally. Out of scope for v1, but the label shouldn't imply more than coverage.)</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="121:1-121:28;5674-5701"><strong>Display — three states:</strong></p>

<div class="overflow-x-auto w-full px-2 mb-6" data-sourcepos="123:1-127:112;5703-6025">
State | Condition | Renders
-- | -- | --
Sourced | sourced_pct > 0 | "{n}% sourced" + colour band
Unverified | sourced_pct == 0 and ≥ 3 checkable fields | "Unverified — help us source this"
Unavailable | score missing/null or < 3 checkable fields | neutral chip or nothing — never "Unverified"

</div>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="129:1-129:73;6027-6099"><strong>Colour bands (on the raw fraction; round only the displayed number):</strong></p>

<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" data-sourcepos="130:1-130:64;6100-6163">
<li class="font-claude-response-body whitespace-normal break-words pl-2" data-sourcepos="130:1-130:64;6100-6163">≥ 0.75 → green · 0.60–0.749 → yellow · &lt; 0.60 (and &gt; 0) → red</li>
</ul>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="132:1-133:19;6165-6273"><strong>Wording:</strong> "sourced" / "cited", not "verified" — the number reflects citation coverage,
not fact-checking.</p>

<p class="font-claude-response-body break-words whitespace-normal" data-sourcepos="135:1-135:25;6275-6299"><strong>Acceptance criteria:</strong></p>

<ul class="contains-task-list" data-sourcepos="136:1-143:64;6300-6928">
<li class="task-list-item" data-sourcepos="136:1-136:48;6300-6347"><input disabled="" type="checkbox"> Badge present on all profiles in the hero</li>
<li class="task-list-item" data-sourcepos="137:1-137:85;6348-6432"><input disabled="" type="checkbox"> Missing/unavailable score never renders "Unverified" (renders neutral/nothing)</li>
<li class="task-list-item" data-sourcepos="138:1-138:78;6433-6510"><input disabled="" type="checkbox"> Genuine 0% (with ≥ 3 fields) renders "Unverified — help us source this"</li>
<li class="task-list-item" data-sourcepos="139:1-139:81;6511-6591"><input disabled="" type="checkbox"> Profiles with &lt; 3 checkable fields render "Limited data", not a percentage</li>
<li class="task-list-item" data-sourcepos="140:1-140:91;6592-6682"><input disabled="" type="checkbox"> Colour band computed on raw value; boundary cases (0.599, 0.60, 0.749, 0.75) correct</li>
<li class="task-list-item" data-sourcepos="141:1-141:94;6683-6776"><input disabled="" type="checkbox"> Band distinguishable without colour (text + icon/shape), meets contrast in light + dark</li>
<li class="task-list-item" data-sourcepos="142:1-142:88;6777-6864"><input disabled="" type="checkbox"> Backend field deployed alongside the frontend (coordination tracked, not assumed)</li>
<li class="task-list-item" data-sourcepos="143:1-143:64;6865-6928"><input disabled="" type="checkbox"> Unit tests cover all three states and every band boundary</li></ul>