### PR TITLE
Add 288 Maharashtra 2024 MLA winners; remove hallucinated MLA records

### DIFF
--- a/app/data/mla.json
+++ b/app/data/mla.json
@@ -39266,3366 +39266,6 @@
     "lastUpdated": "2026-06-06T06:46:27.594Z"
   },
   {
-    "id": "0d90b338-76e0-565c-9d12-1b7b43f3c93b",
-    "name": "Dhiraj Deshmukh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Akole",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dhiraj Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Akole. The latest available result shows Dhiraj Deshmukh winning the recently election from Akole as a the party candidate (contested). The latest record places Dhiraj Deshmukh in Maharashtra with the the party ticket for Akole.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "b6627882-d765-5c03-9f60-10bc36306ac7",
-    "name": "Sanjay Otago",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ambarnath",
-    "party": "SHIVSENA",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sanjay Otago is a Maharashtra leader and Member of the Legislative Assembly from Ambarnath. The latest available result shows Sanjay Otago winning the recently election from Ambarnath as a the party candidate (contested). The latest record places Sanjay Otago in Maharashtra with the the party ticket for Ambarnath.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "c704132c-6ae3-5faa-a782-06e7299edd85",
-    "name": "Surendra Bagul",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Amalner",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Surendra Bagul is a Maharashtra leader and Member of the Legislative Assembly from Amalner. The latest available result shows Surendra Bagul winning the recently election from Amalner as a the party candidate (contested). The latest record places Surendra Bagul in Maharashtra with the the party ticket for Amalner.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "e75641c7-2ea2-557a-a86a-f3638f44fe36",
-    "name": "None (Anandpur Sahib is in Punjab, not Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Anandpur Sahib",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Anandpur Sahib is in Punjab, not Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Anandpur Sahib. The latest available result shows None (Anandpur Sahib is in Punjab, not Maharashtra) winning the recently election from Anandpur Sahib as a the party candidate (contested). The latest record places None (Anandpur Sahib is in Punjab, not Maharashtra) in Maharashtra with the the party ticket for Anandpur Sahib.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "787cc418-59cb-537b-b1d5-4118c1b3ed19",
-    "name": "None (Aramgadh is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Aramgadh",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Aramgadh is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Aramgadh. The latest available result shows None (Aramgadh is not in Maharashtra) winning the recently election from Aramgadh as a the party candidate (contested). The latest record places None (Aramgadh is not in Maharashtra) in Maharashtra with the the party ticket for Aramgadh.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "44725a62-3abb-5031-a450-932310a92101",
-    "name": "Siddharth More",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Aurangabad Central",
-    "party": "SHIVSENA",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Siddharth More is a Maharashtra leader and Member of the Legislative Assembly from Aurangabad Central. The latest available result shows Siddharth More winning the recently election from Aurangabad Central as a the party candidate (contested). The latest record places Siddharth More in Maharashtra with the the party ticket for Aurangabad Central.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "912251b7-be2b-52af-b575-0b0e7629cf24",
-    "name": "Atuljaibhai Gogoi",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Aurangabad East",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Atuljaibhai Gogoi is a Maharashtra leader and Member of the Legislative Assembly from Aurangabad East. The latest available result shows Atuljaibhai Gogoi winning the recently election from Aurangabad East as a the party candidate (contested). The latest record places Atuljaibhai Gogoi in Maharashtra with the the party ticket for Aurangabad East.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "265599b6-fa14-56f0-83e9-f70f2c351d1a",
-    "name": "Chandrakant Sitaram Kadu",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Aurangabad West",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Chandrakant Sitaram Kadu is a Maharashtra leader and Member of the Legislative Assembly from Aurangabad West. The latest available result shows Chandrakant Sitaram Kadu winning the recently election from Aurangabad West as a the party candidate (contested). The latest record places Chandrakant Sitaram Kadu in Maharashtra with the the party ticket for Aurangabad West.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "8a0a2661-f06e-59d2-be99-1656a2f9c445",
-    "name": "None (Babai is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Babai",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Babai is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Babai. The latest available result shows None (Babai is not in Maharashtra) winning the recently election from Babai as a the party candidate (contested). The latest record places None (Babai is not in Maharashtra) in Maharashtra with the the party ticket for Babai.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0bea091c-07a6-5046-842b-71be0936c3df",
-    "name": "None (Badaun is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Badaun",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Badaun is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Badaun. The latest available result shows None (Badaun is not in Maharashtra) winning the recently election from Badaun as a the party candidate (contested). The latest record places None (Badaun is not in Maharashtra) in Maharashtra with the the party ticket for Badaun.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "e81bbf14-fff4-55fc-99de-4b62ffc2cc1f",
-    "name": "Ravi Rana",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Badlapur",
-    "party": "SHIVSENA",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Ravi Rana is a Maharashtra leader and Member of the Legislative Assembly from Badlapur. The latest available result shows Ravi Rana winning the recently election from Badlapur as a the party candidate (contested). The latest record places Ravi Rana in Maharashtra with the the party ticket for Badlapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "eeb1ca0a-ebd7-5870-92dc-05348e10ae09",
-    "name": "None (Bahrain is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bahrain",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Bahrain is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Bahrain. The latest available result shows None (Bahrain is not in Maharashtra) winning the recently election from Bahrain as a the party candidate (contested). The latest record places None (Bahrain is not in Maharashtra) in Maharashtra with the the party ticket for Bahrain.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "683b7b9b-5a08-551d-a1cc-4c7a4ed1e743",
-    "name": "None (Balghar is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Balghar",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Balghar is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Balghar. The latest available result shows None (Balghar is not in Maharashtra) winning the recently election from Balghar as a the party candidate (contested). The latest record places None (Balghar is not in Maharashtra) in Maharashtra with the the party ticket for Balghar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0c8ef9fc-a8f0-525f-a852-81a2979641c8",
-    "name": "None (Ballia is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ballia",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Ballia is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Ballia. The latest available result shows None (Ballia is not in Maharashtra) winning the recently election from Ballia as a the party candidate (contested). The latest record places None (Ballia is not in Maharashtra) in Maharashtra with the the party ticket for Ballia.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0144945c-d73a-5cc8-8d4a-2add95baaacb",
-    "name": "None (Bandipora is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bandipora",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Bandipora is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Bandipora. The latest available result shows None (Bandipora is not in Maharashtra) winning the recently election from Bandipora as a the party candidate (contested). The latest record places None (Bandipora is not in Maharashtra) in Maharashtra with the the party ticket for Bandipora.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a6099491-52e5-53eb-aa4e-8538de56ba8f",
-    "name": "Rahul Eknath Khairmode",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Baramati",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rahul Eknath Khairmode is a Maharashtra leader and Member of the Legislative Assembly from Baramati. The latest available result shows Rahul Eknath Khairmode winning the recently election from Baramati as a the party candidate (contested). The latest record places Rahul Eknath Khairmode in Maharashtra with the the party ticket for Baramati.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "41d60ce7-cb18-580d-b0f4-28c9ed249bf2",
-    "name": "None (Basti is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Basti",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Basti is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Basti. The latest available result shows None (Basti is not in Maharashtra) winning the recently election from Basti as a the party candidate (contested). The latest record places None (Basti is not in Maharashtra) in Maharashtra with the the party ticket for Basti.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "def49112-829b-51fa-9bc0-6d61e8614be1",
-    "name": "Dhananjay Munde",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Beed",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dhananjay Munde is a Maharashtra leader and Member of the Legislative Assembly from Beed. The latest available result shows Dhananjay Munde winning the recently election from Beed as a the party candidate (contested). The latest record places Dhananjay Munde in Maharashtra with the the party ticket for Beed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "caefd9aa-0579-5be2-a7df-9487febbf610",
-    "name": "None (Bhamragad is in Gadchiroli district)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhamragad",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Bhamragad is in Gadchiroli district) is a Maharashtra leader and Member of the Legislative Assembly from Bhamragad. The latest available result shows None (Bhamragad is in Gadchiroli district) winning the recently election from Bhamragad as a the party candidate (contested). The latest record places None (Bhamragad is in Gadchiroli district) in Maharashtra with the the party ticket for Bhamragad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "4a298e32-c8bf-594b-bc20-3f75dbbf3ff5",
-    "name": "Rajendra Jagdale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhandara",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajendra Jagdale is a Maharashtra leader and Member of the Legislative Assembly from Bhandara. The latest available result shows Rajendra Jagdale winning the recently election from Bhandara as a the party candidate (contested). The latest record places Rajendra Jagdale in Maharashtra with the the party ticket for Bhandara.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "9518530d-3004-5283-b014-edfd728b53d0",
-    "name": "None (Bharuch is in Gujarat, not Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bharuch",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Bharuch is in Gujarat, not Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Bharuch. The latest available result shows None (Bharuch is in Gujarat, not Maharashtra) winning the recently election from Bharuch as a the party candidate (contested). The latest record places None (Bharuch is in Gujarat, not Maharashtra) in Maharashtra with the the party ticket for Bharuch.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "43260fc9-51d4-57fe-838f-4463eb08346c",
-    "name": "Kishor Chhabria",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhatkuli",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Kishor Chhabria is a Maharashtra leader and Member of the Legislative Assembly from Bhatkuli. The latest available result shows Kishor Chhabria winning the recently election from Bhatkuli as a the party candidate (contested). The latest record places Kishor Chhabria in Maharashtra with the the party ticket for Bhatkuli.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "55227b61-19d2-5e75-8acb-0e1328b9e94f",
-    "name": "None (Bhaura is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhaura",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Bhaura is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Bhaura. The latest available result shows None (Bhaura is not in Maharashtra) winning the recently election from Bhaura as a the party candidate (contested). The latest record places None (Bhaura is not in Maharashtra) in Maharashtra with the the party ticket for Bhaura.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "30536e56-1872-57fa-a248-18dbfdbb29a1",
-    "name": "None (Bhawani is not in Maharashtra)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhawani",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Bhawani is not in Maharashtra) is a Maharashtra leader and Member of the Legislative Assembly from Bhawani. The latest available result shows None (Bhawani is not in Maharashtra) winning the recently election from Bhawani as a the party candidate (contested). The latest record places None (Bhawani is not in Maharashtra) in Maharashtra with the the party ticket for Bhawani.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "6bdc8ecc-159e-5599-84fa-5268f40ce21d",
-    "name": "Ravindra Sangle",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhiwandi Rural",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Ravindra Sangle is a Maharashtra leader and Member of the Legislative Assembly from Bhiwandi Rural. The latest available result shows Ravindra Sangle winning the recently election from Bhiwandi Rural as a the party candidate (contested). The latest record places Ravindra Sangle in Maharashtra with the the party ticket for Bhiwandi Rural.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "53a288e9-045f-538c-82e0-306fee189748",
-    "name": "Shiv Sena",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhiwandi West",
-    "party": "SHIVSENA",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Shiv Sena is a Maharashtra leader and Member of the Legislative Assembly from Bhiwandi West. The latest available result shows Shiv Sena winning the recently election from Bhiwandi West as a the party candidate (contested). The latest record places Shiv Sena in Maharashtra with the the party ticket for Bhiwandi West.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "9d3889b5-dffb-50e5-944e-964042202a0f",
-    "name": "Sanjeev Zingade",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhokardan",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sanjeev Zingade is a Maharashtra leader and Member of the Legislative Assembly from Bhokardan. The latest available result shows Sanjeev Zingade winning the recently election from Bhokardan as a the party candidate (contested). The latest record places Sanjeev Zingade in Maharashtra with the the party ticket for Bhokardan.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "db266416-6a88-514c-9f8b-92f957b41119",
-    "name": "Aditi Tatkare",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Bhum",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Aditi Tatkare is a Maharashtra leader and Member of the Legislative Assembly from Bhum. The latest available result shows Aditi Tatkare winning the recently election from Bhum as a the party candidate (contested). The latest record places Aditi Tatkare in Maharashtra with the the party ticket for Bhum.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "52d9c8d1-3d77-5628-8490-c366deb0eb06",
-    "name": "None (Brahmaputra is not a constituency)",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Brahmaputra",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None (Brahmaputra is not a constituency) is a Maharashtra leader and Member of the Legislative Assembly from Brahmaputra. The latest available result shows None (Brahmaputra is not a constituency) winning the recently election from Brahmaputra as a the party candidate (contested). The latest record places None (Brahmaputra is not a constituency) in Maharashtra with the the party ticket for Brahmaputra.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "3c0c6d1b-c2d8-5d72-b003-d198baa9797d",
-    "name": "Anoop Kumar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Chandivali",
-    "party": "SHIVSENA",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Anoop Kumar is a Maharashtra leader and Member of the Legislative Assembly from Chandivali. The latest available result shows Anoop Kumar winning the recently election from Chandivali as a the party candidate (contested). The latest record places Anoop Kumar in Maharashtra with the the party ticket for Chandivali.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "538c21ab-c15e-566f-b43f-86c2cf13fd43",
-    "name": "Arun Bhagat",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ghadge",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Arun Bhagat is a Maharashtra leader and Member of the Legislative Assembly from Ghadge. The latest available result shows Arun Bhagat winning the recently election from Ghadge as a the party candidate (contested). The latest record places Arun Bhagat in Maharashtra with the the party ticket for Ghadge.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ffc97fc1-805b-5517-8ba6-1cd836edf7f6",
-    "name": "Tatya Madavi",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ghansawangi",
-    "party": "Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Tatya Madavi is a Maharashtra leader and Member of the Legislative Assembly from Ghansawangi. The latest available result shows Tatya Madavi winning the recently election from Ghansawangi as a the party candidate (contested). The latest record places Tatya Madavi in Maharashtra with the the party ticket for Ghansawangi.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "4d5aeef3-e39c-52a7-a1cc-c2d086d1820f",
-    "name": "Dhaniram Murali",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Gondiya",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dhaniram Murali is a Maharashtra leader and Member of the Legislative Assembly from Gondiya. The latest available result shows Dhaniram Murali winning the recently election from Gondiya as a the party candidate (contested). The latest record places Dhaniram Murali in Maharashtra with the the party ticket for Gondiya.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "5221af6a-a4aa-52dd-ae8c-b2209ec75e93",
-    "name": "Ravidass",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Gowandi",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Ravidass is a Maharashtra leader and Member of the Legislative Assembly from Gowandi. The latest available result shows Ravidass winning the recently election from Gowandi as a the party candidate (contested). The latest record places Ravidass in Maharashtra with the the party ticket for Gowandi.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "2a77849d-1035-5f07-9464-3b23fe3ae995",
-    "name": "Rahul Arlikar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Hinganghat",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rahul Arlikar is a Maharashtra leader and Member of the Legislative Assembly from Hinganghat. The latest available result shows Rahul Arlikar winning the recently election from Hinganghat as a the party candidate (contested). The latest record places Rahul Arlikar in Maharashtra with the the party ticket for Hinganghat.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "e540b32a-b8e1-5855-bdc1-22faad103912",
-    "name": "Santosh Sirf",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Hingoli",
-    "party": "Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Santosh Sirf is a Maharashtra leader and Member of the Legislative Assembly from Hingoli. The latest available result shows Santosh Sirf winning the recently election from Hingoli as a the party candidate (contested). The latest record places Santosh Sirf in Maharashtra with the the party ticket for Hingoli.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "d88e07d7-e0d1-5c60-a2ff-2044bc461624",
-    "name": "Sangita Chaudhari",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ichalkaranji",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sangita Chaudhari is a Maharashtra leader and Member of the Legislative Assembly from Ichalkaranji. The latest available result shows Sangita Chaudhari winning the recently election from Ichalkaranji as a the party candidate (contested). The latest record places Sangita Chaudhari in Maharashtra with the the party ticket for Ichalkaranji.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "fb61e1de-b45b-5aea-9a90-3953347b4edb",
-    "name": "Dhananjay Munde",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Indapur",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dhananjay Munde is a Maharashtra leader and Member of the Legislative Assembly from Indapur. The latest available result shows Dhananjay Munde winning the recently election from Indapur as a the party candidate (contested). The latest record places Dhananjay Munde in Maharashtra with the the party ticket for Indapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "8e890f24-daa8-56de-9fb6-39fdb469fa2a",
-    "name": "Suresh Damodhar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jalgaon (NPS)",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Suresh Damodhar is a Maharashtra leader and Member of the Legislative Assembly from Jalgaon (NPS). The latest available result shows Suresh Damodhar winning the recently election from Jalgaon (NPS) as a the party candidate (contested). The latest record places Suresh Damodhar in Maharashtra with the the party ticket for Jalgaon (NPS).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "08dc6de6-fc13-52b7-88b1-c80d7ecb3598",
-    "name": "Chhagan Bhambhore",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jalgaon Rural",
-    "party": "Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Chhagan Bhambhore is a Maharashtra leader and Member of the Legislative Assembly from Jalgaon Rural. The latest available result shows Chhagan Bhambhore winning the recently election from Jalgaon Rural as a the party candidate (contested). The latest record places Chhagan Bhambhore in Maharashtra with the the party ticket for Jalgaon Rural.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "6221cd6e-ed01-5c97-a9b6-78a7972b7b4f",
-    "name": "Rajesh Patil",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jalgaon Urban",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajesh Patil is a Maharashtra leader and Member of the Legislative Assembly from Jalgaon Urban. The latest available result shows Rajesh Patil winning the recently election from Jalgaon Urban as a the party candidate (contested). The latest record places Rajesh Patil in Maharashtra with the the party ticket for Jalgaon Urban.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0ac789a2-8f47-56da-a4ec-fecb1225c9f2",
-    "name": "Abdulmalik Arbaji",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jalna",
-    "party": "Auradhesh Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Abdulmalik Arbaji is a Maharashtra leader and Member of the Legislative Assembly from Jalna. The latest available result shows Abdulmalik Arbaji winning the recently election from Jalna as a the party candidate (contested). The latest record places Abdulmalik Arbaji in Maharashtra with the the party ticket for Jalna.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "f7669eae-9a5c-51c7-8124-e432b73ade38",
-    "name": "Bhairat Bhalgaon",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jalori",
-    "party": "Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Bhairat Bhalgaon is a Maharashtra leader and Member of the Legislative Assembly from Jalori. The latest available result shows Bhairat Bhalgaon winning the recently election from Jalori as a the party candidate (contested). The latest record places Bhairat Bhalgaon in Maharashtra with the the party ticket for Jalori.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "15f5f856-ec9a-50d0-baea-ce192ef6d523",
-    "name": "Shivaji Gajanan",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jambusare",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Shivaji Gajanan is a Maharashtra leader and Member of the Legislative Assembly from Jambusare. The latest available result shows Shivaji Gajanan winning the recently election from Jambusare as a the party candidate (contested). The latest record places Shivaji Gajanan in Maharashtra with the the party ticket for Jambusare.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "753cf472-a3f2-5407-b206-e967837b8541",
-    "name": "Dinesh Babarao",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jamkhed",
-    "party": "Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dinesh Babarao is a Maharashtra leader and Member of the Legislative Assembly from Jamkhed. The latest available result shows Dinesh Babarao winning the recently election from Jamkhed as a the party candidate (contested). The latest record places Dinesh Babarao in Maharashtra with the the party ticket for Jamkhed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "006eae2d-26bc-53b7-901d-f126509447ee",
-    "name": "Kailas Kadu",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Kandele",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Kailas Kadu is a Maharashtra leader and Member of the Legislative Assembly from Kandele. The latest available result shows Kailas Kadu winning the recently election from Kandele as a the party candidate (contested). The latest record places Kailas Kadu in Maharashtra with the the party ticket for Kandele.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "97d8ede4-5648-53f8-946b-6e74d8ed3509",
-    "name": "Rameshwar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Karjat",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rameshwar is a Maharashtra leader and Member of the Legislative Assembly from Karjat. The latest available result shows Rameshwar winning the recently election from Karjat as a the party candidate (contested). The latest record places Rameshwar in Maharashtra with the the party ticket for Karjat.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "fb319202-5f08-5edd-9554-7e23dd7010bf",
-    "name": "Ravikumar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Khamgaon",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Ravikumar is a Maharashtra leader and Member of the Legislative Assembly from Khamgaon. The latest available result shows Ravikumar winning the recently election from Khamgaon as a the party candidate (contested). The latest record places Ravikumar in Maharashtra with the the party ticket for Khamgaon.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "be123895-b0ca-5e30-a372-8c3f11293cc3",
-    "name": "Pradip Kumar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Khed",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Pradip Kumar is a Maharashtra leader and Member of the Legislative Assembly from Khed. The latest available result shows Pradip Kumar winning the recently election from Khed as a the party candidate (contested). The latest record places Pradip Kumar in Maharashtra with the the party ticket for Khed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "fe834c07-2a70-5f59-ba08-473543b5ab54",
-    "name": "Vishnu",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Khed (Warora)",
-    "party": "Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Vishnu is a Maharashtra leader and Member of the Legislative Assembly from Khed (Warora). The latest available result shows Vishnu winning the recently election from Khed (Warora) as a the party candidate (contested). The latest record places Vishnu in Maharashtra with the the party ticket for Khed (Warora).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a4c133c1-ed17-502b-a9f5-f69edc21249c",
-    "name": "Tanaji",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Kholapur",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Tanaji is a Maharashtra leader and Member of the Legislative Assembly from Kholapur. The latest available result shows Tanaji winning the recently election from Kholapur as a the party candidate (contested). The latest record places Tanaji in Maharashtra with the the party ticket for Kholapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a5a40e6d-fe6d-58f6-b6b5-39febc334891",
-    "name": "Mohammed Hussein Khan",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nanded",
-    "party": "AIMIM",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Mohammed Hussein Khan is a Maharashtra leader and Member of the Legislative Assembly from Nanded. The latest available result shows Mohammed Hussein Khan winning the recently election from Nanded as a the party candidate (contested). The latest record places Mohammed Hussein Khan in Maharashtra with the the party ticket for Nanded.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a22d219a-a654-5389-891c-1b3fde87d456",
-    "name": "Pankaj Bhujbal",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nandgaon",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Pankaj Bhujbal is a Maharashtra leader and Member of the Legislative Assembly from Nandgaon. The latest available result shows Pankaj Bhujbal winning the recently election from Nandgaon as a the party candidate (contested). The latest record places Pankaj Bhujbal in Maharashtra with the the party ticket for Nandgaon.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "dd090ae3-8ef7-5e85-beec-de38a2d8b1d6",
-    "name": "Sudhir Tale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nandura",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sudhir Tale is a Maharashtra leader and Member of the Legislative Assembly from Nandura. The latest available result shows Sudhir Tale winning the recently election from Nandura as a the party candidate (contested). The latest record places Sudhir Tale in Maharashtra with the the party ticket for Nandura.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "8bc85994-fea1-5bd4-b82d-f9d84ee8d24d",
-    "name": "Dr. Rajeev Poddar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Narkhed",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dr. Rajeev Poddar is a Maharashtra leader and Member of the Legislative Assembly from Narkhed. The latest available result shows Dr. Rajeev Poddar winning the recently election from Narkhed as a the party candidate (contested). The latest record places Dr. Rajeev Poddar in Maharashtra with the the party ticket for Narkhed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "be1b0143-e6da-5d88-b303-c8344e46e502",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nathingdon",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Nathingdon. The latest available result shows No MLA winning the recently election from Nathingdon as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Nathingdon.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "bd509c30-45fb-509a-9b80-6f6cb16a6e48",
-    "name": "Sharad Gavit",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Navapur",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sharad Gavit is a Maharashtra leader and Member of the Legislative Assembly from Navapur. The latest available result shows Sharad Gavit winning the recently election from Navapur as a the party candidate (contested). The latest record places Sharad Gavit in Maharashtra with the the party ticket for Navapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "17a4be0e-ec89-5cf9-a25d-f75dbdca62c6",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ner",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Ner. The latest available result shows No MLA winning the recently election from Ner as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Ner.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "5b6a9e6b-81fe-5ba1-8e9b-14ff4f30b419",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nilegaon",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Nilegaon. The latest available result shows No MLA winning the recently election from Nilegaon as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Nilegaon.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "6237062d-e76b-5853-91e7-6d3aec0382b1",
-    "name": "Bhagwanrao Karale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nimgaon Khed",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Bhagwanrao Karale is a Maharashtra leader and Member of the Legislative Assembly from Nimgaon Khed. The latest available result shows Bhagwanrao Karale winning the recently election from Nimgaon Khed as a the party candidate (contested). The latest record places Bhagwanrao Karale in Maharashtra with the the party ticket for Nimgaon Khed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "95798f45-12e7-5de4-9131-dd7fa53415a5",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nirupam",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Nirupam. The latest available result shows No MLA winning the recently election from Nirupam as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Nirupam.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "da2e2ab1-fe25-566e-ab33-7f324668b098",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Nolambur",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Nolambur. The latest available result shows No MLA winning the recently election from Nolambur as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Nolambur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "8caf3f48-7a26-5859-8442-1836b813e4a7",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Numbai",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Numbai. The latest available result shows No MLA winning the recently election from Numbai as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Numbai.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "1f0a0512-0d16-57fc-b368-7a680f08841c",
-    "name": "Kalidas Kolambkar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Osmabad",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Kalidas Kolambkar is a Maharashtra leader and Member of the Legislative Assembly from Osmabad. The latest available result shows Kalidas Kolambkar winning the recently election from Osmabad as a the party candidate (contested). The latest record places Kalidas Kolambkar in Maharashtra with the the party ticket for Osmabad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "3c6fb236-6f35-538c-84b4-49db3ab9a347",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pakhardi",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Pakhardi. The latest available result shows No MLA winning the recently election from Pakhardi as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Pakhardi.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "3a5c857e-cdef-519a-b035-593098edc9c7",
-    "name": "Shrinivas Vanga",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Palghar",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Shrinivas Vanga is a Maharashtra leader and Member of the Legislative Assembly from Palghar. The latest available result shows Shrinivas Vanga winning the recently election from Palghar as a the party candidate (contested). The latest record places Shrinivas Vanga in Maharashtra with the the party ticket for Palghar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "c52941a9-e87d-55e4-ba31-0d04e668e0aa",
-    "name": "Keshav Nandagawali",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Palkhed",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Keshav Nandagawali is a Maharashtra leader and Member of the Legislative Assembly from Palkhed. The latest available result shows Keshav Nandagawali winning the recently election from Palkhed as a the party candidate (contested). The latest record places Keshav Nandagawali in Maharashtra with the the party ticket for Palkhed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "c3385a92-0e01-541c-bb8d-263e0360edd6",
-    "name": "Vijay Bhambale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pandharpur",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Vijay Bhambale is a Maharashtra leader and Member of the Legislative Assembly from Pandharpur. The latest available result shows Vijay Bhambale winning the recently election from Pandharpur as a the party candidate (contested). The latest record places Vijay Bhambale in Maharashtra with the the party ticket for Pandharpur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ce0647f7-e873-51b7-ad36-7073513bb490",
-    "name": "Prashant Thakur",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Panvel",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Prashant Thakur is a Maharashtra leader and Member of the Legislative Assembly from Panvel. The latest available result shows Prashant Thakur winning the recently election from Panvel as a the party candidate (contested). The latest record places Prashant Thakur in Maharashtra with the the party ticket for Panvel.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "b83d55ca-0558-5d32-864f-664413dcda48",
-    "name": "Dhananjay Munde",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Parali Vaijnath",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dhananjay Munde is a Maharashtra leader and Member of the Legislative Assembly from Parali Vaijnath. The latest available result shows Dhananjay Munde winning the recently election from Parali Vaijnath as a the party candidate (contested). The latest record places Dhananjay Munde in Maharashtra with the the party ticket for Parali Vaijnath.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ad2e7369-2b9a-591d-9cc9-d7c79dc92322",
-    "name": "Rahul Patil",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Parbhani",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rahul Patil is a Maharashtra leader and Member of the Legislative Assembly from Parbhani. The latest available result shows Rahul Patil winning the recently election from Parbhani as a the party candidate (contested). The latest record places Rahul Patil in Maharashtra with the the party ticket for Parbhani.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "1b4b8752-28ef-59fc-b664-39684e16dc28",
-    "name": "Suresh Gore",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pathardi",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Suresh Gore is a Maharashtra leader and Member of the Legislative Assembly from Pathardi. The latest available result shows Suresh Gore winning the recently election from Pathardi as a the party candidate (contested). The latest record places Suresh Gore in Maharashtra with the the party ticket for Pathardi.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "be77ccf3-4f48-5ab8-ae02-cea428dfc4ae",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pathawada",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Pathawada. The latest available result shows No MLA winning the recently election from Pathawada as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Pathawada.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0d490c72-e2fd-5c14-85bd-4729085adabc",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Patiyaha",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Patiyaha. The latest available result shows No MLA winning the recently election from Patiyaha as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Patiyaha.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "3bc78e4a-c77e-5617-8d42-4d6e0921d7ec",
-    "name": "Monika Rajale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Patur",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Monika Rajale is a Maharashtra leader and Member of the Legislative Assembly from Patur. The latest available result shows Monika Rajale winning the recently election from Patur as a the party candidate (contested). The latest record places Monika Rajale in Maharashtra with the the party ticket for Patur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "aa775934-4427-541a-baab-20e5bc2add7a",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pawad",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Pawad. The latest available result shows No MLA winning the recently election from Pawad as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Pawad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "9fa3c193-1d95-5f94-8002-1a1c38b8f297",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pawanputra",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Pawanputra. The latest available result shows No MLA winning the recently election from Pawanputra as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Pawanputra.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ae92f574-7dbd-5fa1-93db-a7f61a928700",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Phulnar",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Phulnar. The latest available result shows No MLA winning the recently election from Phulnar as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Phulnar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "c3d3966f-b545-5ad2-9563-66f62aa0834d",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pilkhodad",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Pilkhodad. The latest available result shows No MLA winning the recently election from Pilkhodad as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Pilkhodad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "89e81439-3384-5bba-b735-6313240a496f",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Pinangwan",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Pinangwan. The latest available result shows No MLA winning the recently election from Pinangwan as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Pinangwan.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "c03a3ce0-1c61-5242-abfd-44f6e3b3e23b",
-    "name": "No MLA",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Raichur",
-    "party": "No Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA is a Maharashtra leader and Member of the Legislative Assembly from Raichur. The latest available result shows No MLA winning the recently election from Raichur as a the party candidate (contested). The latest record places No MLA in Maharashtra with the the party ticket for Raichur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0161bd28-525e-5647-9c4d-069586037812",
-    "name": "Amit Bhalekar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Kurla",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Amit Bhalekar is a Maharashtra leader and Member of the Legislative Assembly from Kurla. The latest available result shows Amit Bhalekar winning the recently election from Kurla as a the party candidate (contested). The latest record places Amit Bhalekar in Maharashtra with the the party ticket for Kurla.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "e91cd55a-fe7d-552a-ab65-5152332092e0",
-    "name": "Amit Deshmukh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Latur",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Amit Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Latur. The latest available result shows Amit Deshmukh winning the recently election from Latur as a the party candidate (contested). The latest record places Amit Deshmukh in Maharashtra with the the party ticket for Latur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "d3d66aaf-6a1e-5686-94b9-b5027fdfae0a",
-    "name": "Dhiraj Deshmukh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Latur Rural",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dhiraj Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Latur Rural. The latest available result shows Dhiraj Deshmukh winning the recently election from Latur Rural as a the party candidate (contested). The latest record places Dhiraj Deshmukh in Maharashtra with the the party ticket for Latur Rural.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "880997b2-4633-5750-9d67-e73c975a9232",
-    "name": "Amit Deshmukh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Latur Urban",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Amit Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Latur Urban. The latest available result shows Amit Deshmukh winning the recently election from Latur Urban as a the party candidate (contested). The latest record places Amit Deshmukh in Maharashtra with the the party ticket for Latur Urban.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0477bc5f-3c3d-5bf0-a788-d81240265006",
-    "name": "Prataprao Govindrao Chikhalikar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Loha",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Prataprao Govindrao Chikhalikar is a Maharashtra leader and Member of the Legislative Assembly from Loha. The latest available result shows Prataprao Govindrao Chikhalikar winning the recently election from Loha as a the party candidate (contested). The latest record places Prataprao Govindrao Chikhalikar in Maharashtra with the the party ticket for Loha.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "7697c329-fab5-5203-9bd9-12d71ed532b8",
-    "name": "Prakash Narayanrao Sukhadeve",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Lonar",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Prakash Narayanrao Sukhadeve is a Maharashtra leader and Member of the Legislative Assembly from Lonar. The latest available result shows Prakash Narayanrao Sukhadeve winning the recently election from Lonar as a the party candidate (contested). The latest record places Prakash Narayanrao Sukhadeve in Maharashtra with the the party ticket for Lonar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "f6f0c93a-71d1-5623-bbff-2a06e290c5bb",
-    "name": "Shyam Karadi",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Loni",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Shyam Karadi is a Maharashtra leader and Member of the Legislative Assembly from Loni. The latest available result shows Shyam Karadi winning the recently election from Loni as a the party candidate (contested). The latest record places Shyam Karadi in Maharashtra with the the party ticket for Loni.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "7dfd922e-63f0-5841-9574-873dc8d7012d",
-    "name": "Babasaheb Shankarrao More",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Madha",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Babasaheb Shankarrao More is a Maharashtra leader and Member of the Legislative Assembly from Madha. The latest available result shows Babasaheb Shankarrao More winning the recently election from Madha as a the party candidate (contested). The latest record places Babasaheb Shankarrao More in Maharashtra with the the party ticket for Madha.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "63129189-d1d4-5acc-9485-2f7cffabcf4b",
-    "name": "Mohammad Ismail Abdul Khalid",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Malegaon Central",
-    "party": "Janata Dal (Secular)",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Mohammad Ismail Abdul Khalid is a Maharashtra leader and Member of the Legislative Assembly from Malegaon Central. The latest available result shows Mohammad Ismail Abdul Khalid winning the recently election from Malegaon Central as a the party candidate (contested). The latest record places Mohammad Ismail Abdul Khalid in Maharashtra with the the party ticket for Malegaon Central.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "e0a8efc0-1e4b-5734-8b74-1d9581c10824",
-    "name": "Dadaji Bhuse",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Malegaon Outer",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dadaji Bhuse is a Maharashtra leader and Member of the Legislative Assembly from Malegaon Outer. The latest available result shows Dadaji Bhuse winning the recently election from Malegaon Outer as a the party candidate (contested). The latest record places Dadaji Bhuse in Maharashtra with the the party ticket for Malegaon Outer.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "78c7ad34-76c5-506f-ae19-cebb6f28979c",
-    "name": "Chandrakant Patil",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Malkhed",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Chandrakant Patil is a Maharashtra leader and Member of the Legislative Assembly from Malkhed. The latest available result shows Chandrakant Patil winning the recently election from Malkhed as a the party candidate (contested). The latest record places Chandrakant Patil in Maharashtra with the the party ticket for Malkhed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "78b1769d-2e1d-52ff-9b82-6bd4f3a7ba19",
-    "name": "Shankarrao Gadakh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mangalvedhe",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Shankarrao Gadakh is a Maharashtra leader and Member of the Legislative Assembly from Mangalvedhe. The latest available result shows Shankarrao Gadakh winning the recently election from Mangalvedhe as a the party candidate (contested). The latest record places Shankarrao Gadakh in Maharashtra with the the party ticket for Mangalvedhe.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "9a2e09ae-b266-5a8f-8860-707149a0004e",
-    "name": "Bala Bhegade",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Manjari",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Bala Bhegade is a Maharashtra leader and Member of the Legislative Assembly from Manjari. The latest available result shows Bala Bhegade winning the recently election from Manjari as a the party candidate (contested). The latest record places Bala Bhegade in Maharashtra with the the party ticket for Manjari.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "4af399d5-e43c-570d-a22a-5c6096d84d2d",
-    "name": "Narendra Bhondekar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Manmad",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Narendra Bhondekar is a Maharashtra leader and Member of the Legislative Assembly from Manmad. The latest available result shows Narendra Bhondekar winning the recently election from Manmad as a the party candidate (contested). The latest record places Narendra Bhondekar in Maharashtra with the the party ticket for Manmad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "2ac966be-fa38-5bf2-a848-e840c4cbe5e2",
-    "name": "Prasad Lad",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Manori",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Prasad Lad is a Maharashtra leader and Member of the Legislative Assembly from Manori. The latest available result shows Prasad Lad winning the recently election from Manori as a the party candidate (contested). The latest record places Prasad Lad in Maharashtra with the the party ticket for Manori.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "f57a9ef7-156f-5a56-bd02-e1c06a757a1c",
-    "name": "Rajesh Kshirsagar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Maregaon",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajesh Kshirsagar is a Maharashtra leader and Member of the Legislative Assembly from Maregaon. The latest available result shows Rajesh Kshirsagar winning the recently election from Maregaon as a the party candidate (contested). The latest record places Rajesh Kshirsagar in Maharashtra with the the party ticket for Maregaon.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "5232ea4e-584c-5a6a-b215-3cd0950d2150",
-    "name": "Abdul Sattar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mau",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Abdul Sattar is a Maharashtra leader and Member of the Legislative Assembly from Mau. The latest available result shows Abdul Sattar winning the recently election from Mau as a the party candidate (contested). The latest record places Abdul Sattar in Maharashtra with the the party ticket for Mau.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "9b09c809-40e5-5b96-8a7d-51d920a7046d",
-    "name": "Sanjay Pawar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Maval",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sanjay Pawar is a Maharashtra leader and Member of the Legislative Assembly from Maval. The latest available result shows Sanjay Pawar winning the recently election from Maval as a the party candidate (contested). The latest record places Sanjay Pawar in Maharashtra with the the party ticket for Maval.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "d4128f02-71ac-5ef3-815f-537f7dc1ba89",
-    "name": "Not Available",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Meri Metei",
-    "party": "Not Available",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Not Available is a Maharashtra leader and Member of the Legislative Assembly from Meri Metei. The latest available result shows Not Available winning the recently election from Meri Metei as a the party candidate (contested). The latest record places Not Available in Maharashtra with the the party ticket for Meri Metei.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "f6a490de-87bc-5928-9c96-346680699aa5",
-    "name": "Not Available",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mirajgaon",
-    "party": "Not Available",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Not Available is a Maharashtra leader and Member of the Legislative Assembly from Mirajgaon. The latest available result shows Not Available winning the recently election from Mirajgaon as a the party candidate (contested). The latest record places Not Available in Maharashtra with the the party ticket for Mirajgaon.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a65f7f8e-16df-55fa-978f-fe90601353e9",
-    "name": "Geeta Jain",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mira Road",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Geeta Jain is a Maharashtra leader and Member of the Legislative Assembly from Mira Road. The latest available result shows Geeta Jain winning the recently election from Mira Road as a the party candidate (contested). The latest record places Geeta Jain in Maharashtra with the the party ticket for Mira Road.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "128beaf5-c8dd-522f-ba1a-29e8b36a9138",
-    "name": "Not Available",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mugrabadshahpur",
-    "party": "Not Available",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Not Available is a Maharashtra leader and Member of the Legislative Assembly from Mugrabadshahpur. The latest available result shows Not Available winning the recently election from Mugrabadshahpur as a the party candidate (contested). The latest record places Not Available in Maharashtra with the the party ticket for Mugrabadshahpur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "bffd70d0-460c-55ca-8931-6e10127914a7",
-    "name": "Govind Munnepalliwar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mukhed",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Govind Munnepalliwar is a Maharashtra leader and Member of the Legislative Assembly from Mukhed. The latest available result shows Govind Munnepalliwar winning the recently election from Mukhed as a the party candidate (contested). The latest record places Govind Munnepalliwar in Maharashtra with the the party ticket for Mukhed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "50f3bccc-10b2-5e62-b3ac-3c669e2eeb49",
-    "name": "Yogesh Sagar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mumbai Central",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Yogesh Sagar is a Maharashtra leader and Member of the Legislative Assembly from Mumbai Central. The latest available result shows Yogesh Sagar winning the recently election from Mumbai Central as a the party candidate (contested). The latest record places Yogesh Sagar in Maharashtra with the the party ticket for Mumbai Central.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "9276d02a-6ff5-5b61-adda-0141b55ceb15",
-    "name": "Mohan Dalvi",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mumbai North",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Mohan Dalvi is a Maharashtra leader and Member of the Legislative Assembly from Mumbai North. The latest available result shows Mohan Dalvi winning the recently election from Mumbai North as a the party candidate (contested). The latest record places Mohan Dalvi in Maharashtra with the the party ticket for Mumbai North.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "7ae58b25-9b3a-5b73-ae30-38db093c0e15",
-    "name": "Rahul Narwekar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mumbai North Central",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rahul Narwekar is a Maharashtra leader and Member of the Legislative Assembly from Mumbai North Central. The latest available result shows Rahul Narwekar winning the recently election from Mumbai North Central as a the party candidate (contested). The latest record places Rahul Narwekar in Maharashtra with the the party ticket for Mumbai North Central.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "8393b095-4b47-51c6-a2ab-0758a1a0a1f8",
-    "name": "Rahul Shewale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mumbai North East",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rahul Shewale is a Maharashtra leader and Member of the Legislative Assembly from Mumbai North East. The latest available result shows Rahul Shewale winning the recently election from Mumbai North East as a the party candidate (contested). The latest record places Rahul Shewale in Maharashtra with the the party ticket for Mumbai North East.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "e9f97d0e-7a4b-58ac-88e1-92354a459668",
-    "name": "Aaditya Thackeray",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mumbai North West",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Aaditya Thackeray is a Maharashtra leader and Member of the Legislative Assembly from Mumbai North West. The latest available result shows Aaditya Thackeray winning the recently election from Mumbai North West as a the party candidate (contested). The latest record places Aaditya Thackeray in Maharashtra with the the party ticket for Mumbai North West.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ffac96f7-ad5d-5e9a-bec1-e75ee1d2992f",
-    "name": "Mangal Prabhat Lodha",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mumbai South",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Mangal Prabhat Lodha is a Maharashtra leader and Member of the Legislative Assembly from Mumbai South. The latest available result shows Mangal Prabhat Lodha winning the recently election from Mumbai South as a the party candidate (contested). The latest record places Mangal Prabhat Lodha in Maharashtra with the the party ticket for Mumbai South.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "366b62b2-7a4e-5c67-a128-ba02c9a2e8fd",
-    "name": "Rahul Narwekar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Mumbai South Central",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rahul Narwekar is a Maharashtra leader and Member of the Legislative Assembly from Mumbai South Central. The latest available result shows Rahul Narwekar winning the recently election from Mumbai South Central as a the party candidate (contested). The latest record places Rahul Narwekar in Maharashtra with the the party ticket for Mumbai South Central.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "3a5458fb-3b00-5bb5-9887-5e39637bd4ba",
-    "name": "Prashant Thakur",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Raigad",
-    "party": "Bahujan Vikas Aghadi",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Prashant Thakur is a Maharashtra leader and Member of the Legislative Assembly from Raigad. The latest available result shows Prashant Thakur winning the recently election from Raigad as a the party candidate (contested). The latest record places Prashant Thakur in Maharashtra with the the party ticket for Raigad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "61f41d80-76ca-549e-a4d4-fe5f2af9b7f8",
-    "name": "Pratap Sarnaik",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ovala-Majiwada (part of Thane district, near Raigad)",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Pratap Sarnaik is a Maharashtra leader and Member of the Legislative Assembly from Ovala-Majiwada (part of Thane district, near Raigad). The latest available result shows Pratap Sarnaik winning the recently election from Ovala-Majiwada (part of Thane district, near Raigad) as a the party candidate (contested). The latest record places Pratap Sarnaik in Maharashtra with the the party ticket for Ovala-Majiwada (part of Thane district, near Raigad).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "94f38ec3-bb5c-5ffa-ae45-4dd81b8d053a",
-    "name": "Amit Patil",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Raigarh",
-    "party": "Peasants And Workers Party of India",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Amit Patil is a Maharashtra leader and Member of the Legislative Assembly from Raigarh. The latest available result shows Amit Patil winning the recently election from Raigarh as a the party candidate (contested). The latest record places Amit Patil in Maharashtra with the the party ticket for Raigarh.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "82401deb-6acb-53f7-ac94-ed2150bf17d1",
-    "name": "Rajan Prabhakar Salvi",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Rajapur",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajan Prabhakar Salvi is a Maharashtra leader and Member of the Legislative Assembly from Rajapur. The latest available result shows Rajan Prabhakar Salvi winning the recently election from Rajapur as a the party candidate (contested). The latest record places Rajan Prabhakar Salvi in Maharashtra with the the party ticket for Rajapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0bdd5280-9535-55ef-bbe5-8f284deaa2c6",
-    "name": "Rajendra Rathod",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Rajaramnagar",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajendra Rathod is a Maharashtra leader and Member of the Legislative Assembly from Rajaramnagar. The latest available result shows Rajendra Rathod winning the recently election from Rajaramnagar as a the party candidate (contested). The latest record places Rajendra Rathod in Maharashtra with the the party ticket for Rajaramnagar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "78705982-4b41-5ba1-8239-f2548ed3ad8b",
-    "name": "Rohit Pawar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Karjat (includes Rajgurunagar)",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rohit Pawar is a Maharashtra leader and Member of the Legislative Assembly from Karjat (includes Rajgurunagar). The latest available result shows Rohit Pawar winning the recently election from Karjat (includes Rajgurunagar) as a the party candidate (contested). The latest record places Rohit Pawar in Maharashtra with the the party ticket for Karjat (includes Rajgurunagar).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "933dea07-3749-5c9b-bb89-657eb5d886f8",
-    "name": "Rajesh Deshmukh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Rajpur",
-    "party": "Peasants And Workers Party of India",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajesh Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Rajpur. The latest available result shows Rajesh Deshmukh winning the recently election from Rajpur as a the party candidate (contested). The latest record places Rajesh Deshmukh in Maharashtra with the the party ticket for Rajpur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "275e0e2c-8634-586d-9346-96850391358b",
-    "name": "Rajesh Tope",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ghansawangi (near Rajpura, but not exactly Rajpura)",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajesh Tope is a Maharashtra leader and Member of the Legislative Assembly from Ghansawangi (near Rajpura, but not exactly Rajpura). The latest available result shows Rajesh Tope winning the recently election from Ghansawangi (near Rajpura, but not exactly Rajpura) as a the party candidate (contested). The latest record places Rajesh Tope in Maharashtra with the the party ticket for Ghansawangi (near Rajpura, but not exactly Rajpura).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "54973776-7033-5042-8c5e-42977c73fba2",
-    "name": "Ashish Deshmukh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ramtek",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Ashish Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Ramtek. The latest available result shows Ashish Deshmukh winning the recently election from Ramtek as a the party candidate (contested). The latest record places Ashish Deshmukh in Maharashtra with the the party ticket for Ramtek.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "fd4cb13b-a3c4-51d4-9e08-a6b51e2052e6",
-    "name": "Rajan Prabhakar Salvi",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ratnagiri",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rajan Prabhakar Salvi is a Maharashtra leader and Member of the Legislative Assembly from Ratnagiri. The latest available result shows Rajan Prabhakar Salvi winning the recently election from Ratnagiri as a the party candidate (contested). The latest record places Rajan Prabhakar Salvi in Maharashtra with the the party ticket for Ratnagiri.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ff33fc83-138f-505c-b52b-15bc0aaf546b",
-    "name": "Haribhau Madhukar Jagtap",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Jalgaon Rural (includes Raver)",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Haribhau Madhukar Jagtap is a Maharashtra leader and Member of the Legislative Assembly from Jalgaon Rural (includes Raver). The latest available result shows Haribhau Madhukar Jagtap winning the recently election from Jalgaon Rural (includes Raver) as a the party candidate (contested). The latest record places Haribhau Madhukar Jagtap in Maharashtra with the the party ticket for Jalgaon Rural (includes Raver).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "32cf03ce-cb5b-503e-a8a1-d8cf415fe0e4",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Ribnabad",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Ribnabad. The latest available result shows No MLA found winning the recently election from Ribnabad as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Ribnabad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a9a068e7-ca75-5a84-987e-41807bf61c78",
-    "name": "Amit Zanak",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Risod",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Amit Zanak is a Maharashtra leader and Member of the Legislative Assembly from Risod. The latest available result shows Amit Zanak winning the recently election from Risod as a the party candidate (contested). The latest record places Amit Zanak in Maharashtra with the the party ticket for Risod.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "8322d95d-1ed5-5078-8405-efc380c630d4",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Sawlani",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Sawlani. The latest available result shows No MLA found winning the recently election from Sawlani as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Sawlani.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "0aa51a9a-f853-5426-824f-80200188cc3b",
-    "name": "Sandeep Daundkar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Shahuwadi",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sandeep Daundkar is a Maharashtra leader and Member of the Legislative Assembly from Shahuwadi. The latest available result shows Sandeep Daundkar winning the recently election from Shahuwadi as a the party candidate (contested). The latest record places Sandeep Daundkar in Maharashtra with the the party ticket for Shahuwadi.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "61b479c3-f6d7-564f-9561-7b02597f1191",
-    "name": "Vijay Kale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Shivajinagar",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Vijay Kale is a Maharashtra leader and Member of the Legislative Assembly from Shivajinagar. The latest available result shows Vijay Kale winning the recently election from Shivajinagar as a the party candidate (contested). The latest record places Vijay Kale in Maharashtra with the the party ticket for Shivajinagar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "4fade8d7-e367-5ce7-856c-facef490f835",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Shivpur",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Shivpur. The latest available result shows No MLA found winning the recently election from Shivpur as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Shivpur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "70784d16-2e08-5efb-9a9c-f329f3d2e3b2",
-    "name": "Shriniwas Patil",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Solapur City North (previously known as Sholapur North)",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Shriniwas Patil is a Maharashtra leader and Member of the Legislative Assembly from Solapur City North (previously known as Sholapur North). The latest available result shows Shriniwas Patil winning the recently election from Solapur City North (previously known as Sholapur North) as a the party candidate (contested). The latest record places Shriniwas Patil in Maharashtra with the the party ticket for Solapur City North (previously known as Sholapur North).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "f33a011d-070e-57e3-bcee-2c755ad7789b",
-    "name": "Dilip Mane",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Solapur City South (previously known as Sholapur South)",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dilip Mane is a Maharashtra leader and Member of the Legislative Assembly from Solapur City South (previously known as Sholapur South). The latest available result shows Dilip Mane winning the recently election from Solapur City South (previously known as Sholapur South) as a the party candidate (contested). The latest record places Dilip Mane in Maharashtra with the the party ticket for Solapur City South (previously known as Sholapur South).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "60e72e6d-0bf5-580f-bfc3-a9c2a90b2c87",
-    "name": "Babasaheb Gorthekar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Shrigonda",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Babasaheb Gorthekar is a Maharashtra leader and Member of the Legislative Assembly from Shrigonda. The latest available result shows Babasaheb Gorthekar winning the recently election from Shrigonda as a the party candidate (contested). The latest record places Babasaheb Gorthekar in Maharashtra with the the party ticket for Shrigonda.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "f43aa1af-7dea-5a82-81c0-1113f4094cb2",
-    "name": "Laxman Dhoble",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Shrirampur",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Laxman Dhoble is a Maharashtra leader and Member of the Legislative Assembly from Shrirampur. The latest available result shows Laxman Dhoble winning the recently election from Shrirampur as a the party candidate (contested). The latest record places Laxman Dhoble in Maharashtra with the the party ticket for Shrirampur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "b8068020-9090-598e-b0b9-3cd16dcc9fe9",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Siddhapur",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Siddhapur. The latest available result shows No MLA found winning the recently election from Siddhapur as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Siddhapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "353a9ce3-2db2-56ba-ad46-fc6b3858b81a",
-    "name": "Abdul Sattar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Sillod",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Abdul Sattar is a Maharashtra leader and Member of the Legislative Assembly from Sillod. The latest available result shows Abdul Sattar winning the recently election from Sillod as a the party candidate (contested). The latest record places Abdul Sattar in Maharashtra with the the party ticket for Sillod.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "707633ff-6d7e-529e-bcba-ba2bc9bf3764",
-    "name": "Dilip Mane",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Solapur",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Dilip Mane is a Maharashtra leader and Member of the Legislative Assembly from Solapur. The latest available result shows Dilip Mane winning the recently election from Solapur as a the party candidate (contested). The latest record places Dilip Mane in Maharashtra with the the party ticket for Solapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ff39ef7d-89d7-5441-91ea-a482ebd4b491",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Sonkhed",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Sonkhed. The latest available result shows No MLA found winning the recently election from Sonkhed as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Sonkhed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "72d2940c-3f55-5d4b-ab8c-d5cc9b94cd9d",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Subhashnagar",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Subhashnagar. The latest available result shows No MLA found winning the recently election from Subhashnagar as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Subhashnagar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "3ad4af87-c49a-5d25-a46e-fe1e904bce1b",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Sujawal",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Sujawal. The latest available result shows No MLA found winning the recently election from Sujawal as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Sujawal.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "b93b1e64-ad73-5745-90e8-f9d5b01d2cb4",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Supergaon",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Supergaon. The latest available result shows No MLA found winning the recently election from Supergaon as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Supergaon.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "fd47fe7b-fdbb-5424-8ec8-06197d45cd00",
-    "name": "No MLA found in Maharashtra",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Surat",
-    "party": "No party found, Surat is in Gujarat",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found in Maharashtra is a Maharashtra leader and Member of the Legislative Assembly from Surat. The latest available result shows No MLA found in Maharashtra winning the recently election from Surat as a the party candidate (contested). The latest record places No MLA found in Maharashtra in Maharashtra with the the party ticket for Surat.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "b5abbcfc-d646-57be-97c4-de99a45fb13e",
-    "name": "No MLA found",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Surgana",
-    "party": "No party found",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "No MLA found is a Maharashtra leader and Member of the Legislative Assembly from Surgana. The latest available result shows No MLA found winning the recently election from Surgana as a the party candidate (contested). The latest record places No MLA found in Maharashtra with the the party ticket for Surgana.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "577e2558-f2c1-5a68-a609-4bae1c3582fe",
-    "name": "Kelkar Sanjay Mukund",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Thane",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Kelkar Sanjay Mukund is a Maharashtra leader and Member of the Legislative Assembly from Thane. The latest available result shows Kelkar Sanjay Mukund winning the recently election from Thane as a the party candidate (contested). The latest record places Kelkar Sanjay Mukund in Maharashtra with the the party ticket for Thane.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "e03a468c-b9df-5829-a957-73a49d336137",
-    "name": "Rais Shaikh",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Thane (Bhiwandi)",
-    "party": "Samajwadi Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rais Shaikh is a Maharashtra leader and Member of the Legislative Assembly from Thane (Bhiwandi). The latest available result shows Rais Shaikh winning the recently election from Thane (Bhiwandi) as a the party candidate (contested). The latest record places Rais Shaikh in Maharashtra with the the party ticket for Thane (Bhiwandi).",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "38681431-2b11-52d1-a9da-194e34e03783",
-    "name": "Vijay Bharatlal Rahangdale",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Tiroda",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Vijay Bharatlal Rahangdale is a Maharashtra leader and Member of the Legislative Assembly from Tiroda. The latest available result shows Vijay Bharatlal Rahangdale winning the recently election from Tiroda as a the party candidate (contested). The latest record places Vijay Bharatlal Rahangdale in Maharashtra with the the party ticket for Tiroda.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "60e4dd1b-0774-585f-947d-faed4b280e78",
-    "name": "Madhukarrao Bhagwantrao Chavan",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Tuljapur",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Madhukarrao Bhagwantrao Chavan is a Maharashtra leader and Member of the Legislative Assembly from Tuljapur. The latest available result shows Madhukarrao Bhagwantrao Chavan winning the recently election from Tuljapur as a the party candidate (contested). The latest record places Madhukarrao Bhagwantrao Chavan in Maharashtra with the the party ticket for Tuljapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "349fb5b7-ddb2-5e99-9249-0934e0141c6f",
-    "name": "Namdev Jayram Sasane",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Umarkhed",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Namdev Jayram Sasane is a Maharashtra leader and Member of the Legislative Assembly from Umarkhed. The latest available result shows Namdev Jayram Sasane winning the recently election from Umarkhed as a the party candidate (contested). The latest record places Namdev Jayram Sasane in Maharashtra with the the party ticket for Umarkhed.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "5c0d6507-2ce6-55ae-a6c4-20a4ee1c94e1",
-    "name": "Sukhadeorao Thorat",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Umari",
-    "party": "Indian National Congress",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sukhadeorao Thorat is a Maharashtra leader and Member of the Legislative Assembly from Umari. The latest available result shows Sukhadeorao Thorat winning the recently election from Umari as a the party candidate (contested). The latest record places Sukhadeorao Thorat in Maharashtra with the the party ticket for Umari.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "c392d4cc-ff04-5d39-bd96-cd68a7110159",
-    "name": "None",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Umarkote",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None is a Maharashtra leader and Member of the Legislative Assembly from Umarkote. The latest available result shows None winning the recently election from Umarkote as a the party candidate (contested). The latest record places None in Maharashtra with the the party ticket for Umarkote.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "ec5dfc73-989b-5717-95f5-98a19b04b0e3",
-    "name": "None",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Umne",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None is a Maharashtra leader and Member of the Legislative Assembly from Umne. The latest available result shows None winning the recently election from Umne as a the party candidate (contested). The latest record places None in Maharashtra with the the party ticket for Umne.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "60245fc7-01d9-5950-aafd-f1e309135aab",
-    "name": "Rangnath Wani",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Vaijapur",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Rangnath Wani is a Maharashtra leader and Member of the Legislative Assembly from Vaijapur. The latest available result shows Rangnath Wani winning the recently election from Vaijapur as a the party candidate (contested). The latest record places Rangnath Wani in Maharashtra with the the party ticket for Vaijapur.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a09a1ffe-3ced-5651-ab49-70161ef9cc1d",
-    "name": "Samir Trambakrao Kunawar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Vani",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Samir Trambakrao Kunawar is a Maharashtra leader and Member of the Legislative Assembly from Vani. The latest available result shows Samir Trambakrao Kunawar winning the recently election from Vani as a the party candidate (contested). The latest record places Samir Trambakrao Kunawar in Maharashtra with the the party ticket for Vani.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "fb0ca01b-f7cb-54e3-a2cd-90609ef1cfa6",
-    "name": "None",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Vapi",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None is a Maharashtra leader and Member of the Legislative Assembly from Vapi. The latest available result shows None winning the recently election from Vapi as a the party candidate (contested). The latest record places None in Maharashtra with the the party ticket for Vapi.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "d271c78b-9236-56c1-a07d-dedfde9a025a",
-    "name": "None",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Varal",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None is a Maharashtra leader and Member of the Legislative Assembly from Varal. The latest available result shows None winning the recently election from Varal as a the party candidate (contested). The latest record places None in Maharashtra with the the party ticket for Varal.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "6f90c3b4-0e59-5daf-8d56-aaa57fd5fc13",
-    "name": "None",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Vasantnagar",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None is a Maharashtra leader and Member of the Legislative Assembly from Vasantnagar. The latest available result shows None winning the recently election from Vasantnagar as a the party candidate (contested). The latest record places None in Maharashtra with the the party ticket for Vasantnagar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "fd4fab3c-e20d-540b-ac8e-bdbd40fcfc3b",
-    "name": "None",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Vibhajee Nagar",
-    "party": "None",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "None is a Maharashtra leader and Member of the Legislative Assembly from Vibhajee Nagar. The latest available result shows None winning the recently election from Vibhajee Nagar as a the party candidate (contested). The latest record places None in Maharashtra with the the party ticket for Vibhajee Nagar.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "a1e8d596-ebab-5be6-a738-f77a0b15e55e",
-    "name": "Chimaji Raghunath Patil",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Vikramgad",
-    "party": "Nationalist Congress Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Chimaji Raghunath Patil is a Maharashtra leader and Member of the Legislative Assembly from Vikramgad. The latest available result shows Chimaji Raghunath Patil winning the recently election from Vikramgad as a the party candidate (contested). The latest record places Chimaji Raghunath Patil in Maharashtra with the the party ticket for Vikramgad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "4a43414c-1e86-5d91-92f9-faac0c42ca6d",
-    "name": "Subhash Desai",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Vita",
-    "party": "Shiv Sena",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Subhash Desai is a Maharashtra leader and Member of the Legislative Assembly from Vita. The latest available result shows Subhash Desai winning the recently election from Vita as a the party candidate (contested). The latest record places Subhash Desai in Maharashtra with the the party ticket for Vita.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "b80840d2-7de4-586f-a06c-ac5251edb65d",
-    "name": "Sunil Tingre",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Wakad",
-    "party": "Peasants And Workers Party of India",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Sunil Tingre is a Maharashtra leader and Member of the Legislative Assembly from Wakad. The latest available result shows Sunil Tingre winning the recently election from Wakad as a the party candidate (contested). The latest record places Sunil Tingre in Maharashtra with the the party ticket for Wakad.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "548e8112-7107-57af-97bb-a85fa2927e93",
-    "name": "Pankaj Rajesh Bhoyar",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Wardha",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Pankaj Rajesh Bhoyar is a Maharashtra leader and Member of the Legislative Assembly from Wardha. The latest available result shows Pankaj Rajesh Bhoyar winning the recently election from Wardha as a the party candidate (contested). The latest record places Pankaj Rajesh Bhoyar in Maharashtra with the the party ticket for Wardha.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
-    "id": "23b350f9-0016-50e4-bb36-4ffa9c680ead",
-    "name": "Prashant Thakur",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Washi",
-    "party": "Bharatiya Janata Party",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Prashant Thakur is a Maharashtra leader and Member of the Legislative Assembly from Washi. The latest available result shows Prashant Thakur winning the recently election from Washi as a the party candidate (contested). The latest record places Prashant Thakur in Maharashtra with the the party ticket for Washi.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
     "id": "dd96d09c-8c9d-54a9-a59a-6862497b9bb6",
     "name": "SS Olish",
     "photo": null,
@@ -91204,27 +87844,6 @@
     "lastUpdated": "2026-06-06T06:46:27.594Z"
   },
   {
-    "id": "53e67aa2-b59c-4473-8c33-f48956c5662c",
-    "name": "Vinod Agrawal",
-    "photo": null,
-    "state": "Maharashtra",
-    "constituency": "Gondiya",
-    "party": "Bharatiya Janata Party (BJP)",
-    "type": "MLA",
-    "education": null,
-    "family_background": null,
-    "criminal_records": null,
-    "social_media": null,
-    "contact": null,
-    "political_background": {
-      "elections": [],
-      "summary": "Vinod Agrawal is a Maharashtra leader and Member of the Legislative Assembly from Gondiya. The latest available result shows Vinod Agrawal winning the recently election from Gondiya as a the party candidate (contested). The latest record places Vinod Agrawal in Maharashtra with the the party ticket for Gondiya.",
-      "summary_citation": null
-    },
-    "notes": null,
-    "lastUpdated": "2026-06-06T06:46:27.594Z"
-  },
-  {
     "id": "eef9dae5-09a3-56f4-b7f7-b0d8651c4b6b",
     "name": "Tsering Lhamu",
     "photo": null,
@@ -100764,5 +97383,9797 @@
       "summary_citation": null
     },
     "lastUpdated": "2026-06-06T06:46:27.594Z"
+  },
+  {
+    "id": "0123bccc-fe64-4026-985b-c04e5b8b83e8",
+    "name": "Aamshya Padavi",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Akkalkuwa (ST)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Akkalkuwa (ST)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Aamshya Padavi is a Maharashtra leader and Member of the Legislative Assembly from Akkalkuwa (ST). The latest available result shows Aamshya Padavi winning the 2024 election from Akkalkuwa (ST) as a Shiv Sena candidate (WON). The latest record places Aamshya Padavi in Maharashtra with the Shiv Sena ticket for Akkalkuwa (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ba4fb17a-63b6-49ea-aec8-dd5a72ce6f78",
+    "name": "Rajesh Padvi",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shahada (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shahada (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajesh Padvi is a Maharashtra leader and Member of the Legislative Assembly from Shahada (ST). The latest available result shows Rajesh Padvi winning the 2024 election from Shahada (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Rajesh Padvi in Maharashtra with the Bharatiya Janata Party ticket for Shahada (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ba0a55cf-87f2-412f-bc42-e5e9e81477c6",
+    "name": "Vijaykumar Gavit",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nandurbar (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nandurbar (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vijaykumar Gavit is a Maharashtra leader and Member of the Legislative Assembly from Nandurbar (ST). The latest available result shows Vijaykumar Gavit winning the 2024 election from Nandurbar (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Vijaykumar Gavit in Maharashtra with the Bharatiya Janata Party ticket for Nandurbar (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a6d1062e-4401-4fcc-b557-07b985b27fb2",
+    "name": "Shirishkumar Naik",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Navapur (ST)",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Navapur (ST)",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shirishkumar Naik is a Maharashtra leader and Member of the Legislative Assembly from Navapur (ST). The latest available result shows Shirishkumar Naik winning the 2024 election from Navapur (ST) as a Indian National Congress candidate (WON). The latest record places Shirishkumar Naik in Maharashtra with the Indian National Congress ticket for Navapur (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b61741ab-04cf-453e-bce8-ff66aa24eea4",
+    "name": "Manjula Gavit",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sakri (ST)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sakri (ST)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Manjula Gavit is a Maharashtra leader and Member of the Legislative Assembly from Sakri (ST). The latest available result shows Manjula Gavit winning the 2024 election from Sakri (ST) as a Shiv Sena candidate (WON). The latest record places Manjula Gavit in Maharashtra with the Shiv Sena ticket for Sakri (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "fd3574c7-1fda-4e93-87a5-62f3567d8617",
+    "name": "Raghavendra Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dhule Rural",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dhule Rural",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Raghavendra Patil is a Maharashtra leader and Member of the Legislative Assembly from Dhule Rural. The latest available result shows Raghavendra Patil winning the 2024 election from Dhule Rural as a Bharatiya Janata Party candidate (WON). The latest record places Raghavendra Patil in Maharashtra with the Bharatiya Janata Party ticket for Dhule Rural.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9ead0091-e8c0-4aa1-8f5b-82f9bda62da0",
+    "name": "Anup Agarwal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dhule City",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dhule City",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Anup Agarwal is a Maharashtra leader and Member of the Legislative Assembly from Dhule City. The latest available result shows Anup Agarwal winning the 2024 election from Dhule City as a Bharatiya Janata Party candidate (WON). The latest record places Anup Agarwal in Maharashtra with the Bharatiya Janata Party ticket for Dhule City.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "bd645440-47bf-4c75-a2ca-68b2d0f9edf6",
+    "name": "Jayakumar Rawal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sindkheda",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sindkheda",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Jayakumar Rawal is a Maharashtra leader and Member of the Legislative Assembly from Sindkheda. The latest available result shows Jayakumar Rawal winning the 2024 election from Sindkheda as a Bharatiya Janata Party candidate (WON). The latest record places Jayakumar Rawal in Maharashtra with the Bharatiya Janata Party ticket for Sindkheda.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "243b673b-b303-45d4-9ae6-b8a5029088ee",
+    "name": "Kashiram Pawara",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shirpur (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shirpur (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kashiram Pawara is a Maharashtra leader and Member of the Legislative Assembly from Shirpur (ST). The latest available result shows Kashiram Pawara winning the 2024 election from Shirpur (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Kashiram Pawara in Maharashtra with the Bharatiya Janata Party ticket for Shirpur (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0104fc46-bb74-4e7f-8ba4-20228f655a1e",
+    "name": "Chandrakant Sonawane",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chopda (ST)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chopda (ST)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chandrakant Sonawane is a Maharashtra leader and Member of the Legislative Assembly from Chopda (ST). The latest available result shows Chandrakant Sonawane winning the 2024 election from Chopda (ST) as a Shiv Sena candidate (WON). The latest record places Chandrakant Sonawane in Maharashtra with the Shiv Sena ticket for Chopda (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8baba892-ea66-49af-a2be-df0f4358880b",
+    "name": "Amol Jawale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Raver",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Raver",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Amol Jawale is a Maharashtra leader and Member of the Legislative Assembly from Raver. The latest available result shows Amol Jawale winning the 2024 election from Raver as a Bharatiya Janata Party candidate (WON). The latest record places Amol Jawale in Maharashtra with the Bharatiya Janata Party ticket for Raver.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a25ca075-1fa2-4dcc-a723-b6b4e82b8413",
+    "name": "Sanjay Savkare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhusawal (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhusawal (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Savkare is a Maharashtra leader and Member of the Legislative Assembly from Bhusawal (SC). The latest available result shows Sanjay Savkare winning the 2024 election from Bhusawal (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Sanjay Savkare in Maharashtra with the Bharatiya Janata Party ticket for Bhusawal (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "79d73f38-4bdd-4759-ac8d-2e38f75c9cb1",
+    "name": "Suresh Bhole",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jalgaon City",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jalgaon City",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Suresh Bhole is a Maharashtra leader and Member of the Legislative Assembly from Jalgaon City. The latest available result shows Suresh Bhole winning the 2024 election from Jalgaon City as a Bharatiya Janata Party candidate (WON). The latest record places Suresh Bhole in Maharashtra with the Bharatiya Janata Party ticket for Jalgaon City.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0bff4666-4c05-4a09-8f4e-fdaeb12037ec",
+    "name": "Gulabrao Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jalgaon Rural",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jalgaon Rural",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Gulabrao Patil is a Maharashtra leader and Member of the Legislative Assembly from Jalgaon Rural. The latest available result shows Gulabrao Patil winning the 2024 election from Jalgaon Rural as a Shiv Sena candidate (WON). The latest record places Gulabrao Patil in Maharashtra with the Shiv Sena ticket for Jalgaon Rural.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "45889ce9-ce5d-4cd7-bfa5-38ff62007929",
+    "name": "Anil Bhaidas Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Amalner",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Amalner",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Anil Bhaidas Patil is a Maharashtra leader and Member of the Legislative Assembly from Amalner. The latest available result shows Anil Bhaidas Patil winning the 2024 election from Amalner as a Nationalist Congress Party candidate (WON). The latest record places Anil Bhaidas Patil in Maharashtra with the Nationalist Congress Party ticket for Amalner.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "440acb6a-d812-4cfd-a5b6-8fcc671584ce",
+    "name": "Amol Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Erandol",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Erandol",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Amol Patil is a Maharashtra leader and Member of the Legislative Assembly from Erandol. The latest available result shows Amol Patil winning the 2024 election from Erandol as a Shiv Sena candidate (WON). The latest record places Amol Patil in Maharashtra with the Shiv Sena ticket for Erandol.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1f9a4917-4719-4ded-a711-c1d8b64bc67d",
+    "name": "Mangesh Chavan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chalisgaon",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chalisgaon",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mangesh Chavan is a Maharashtra leader and Member of the Legislative Assembly from Chalisgaon. The latest available result shows Mangesh Chavan winning the 2024 election from Chalisgaon as a Bharatiya Janata Party candidate (WON). The latest record places Mangesh Chavan in Maharashtra with the Bharatiya Janata Party ticket for Chalisgaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6669a267-3167-4ce4-a844-33a61c8a2e59",
+    "name": "Kishor Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Pachora",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Pachora",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kishor Patil is a Maharashtra leader and Member of the Legislative Assembly from Pachora. The latest available result shows Kishor Patil winning the 2024 election from Pachora as a Shiv Sena candidate (WON). The latest record places Kishor Patil in Maharashtra with the Shiv Sena ticket for Pachora.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c83d1ebd-4ff7-4677-8744-781df3b02737",
+    "name": "Girish Mahajan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jamner",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jamner",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Girish Mahajan is a Maharashtra leader and Member of the Legislative Assembly from Jamner. The latest available result shows Girish Mahajan winning the 2024 election from Jamner as a Bharatiya Janata Party candidate (WON). The latest record places Girish Mahajan in Maharashtra with the Bharatiya Janata Party ticket for Jamner.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "e69b2e4e-770c-482f-b059-e06ed1daac2f",
+    "name": "Chandrakant Nimba Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Muktainagar",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Muktainagar",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chandrakant Nimba Patil is a Maharashtra leader and Member of the Legislative Assembly from Muktainagar. The latest available result shows Chandrakant Nimba Patil winning the 2024 election from Muktainagar as a Shiv Sena candidate (WON). The latest record places Chandrakant Nimba Patil in Maharashtra with the Shiv Sena ticket for Muktainagar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "eb651735-3b3f-4dfd-8cf4-c1fb8aaaf52e",
+    "name": "Chainsukh Sancheti",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Malkapur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Malkapur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chainsukh Sancheti is a Maharashtra leader and Member of the Legislative Assembly from Malkapur. The latest available result shows Chainsukh Sancheti winning the 2024 election from Malkapur as a Bharatiya Janata Party candidate (WON). The latest record places Chainsukh Sancheti in Maharashtra with the Bharatiya Janata Party ticket for Malkapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d8d9fb93-0fb5-42b4-97cd-30cab2a3b708",
+    "name": "Sanjay Gaikwad",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Buldhana",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Buldhana",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Gaikwad is a Maharashtra leader and Member of the Legislative Assembly from Buldhana. The latest available result shows Sanjay Gaikwad winning the 2024 election from Buldhana as a Shiv Sena candidate (WON). The latest record places Sanjay Gaikwad in Maharashtra with the Shiv Sena ticket for Buldhana.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "edd28f80-c58d-40ca-a970-33937ec88cc6",
+    "name": "Shweta Mahale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chikhali",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chikhali",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shweta Mahale is a Maharashtra leader and Member of the Legislative Assembly from Chikhali. The latest available result shows Shweta Mahale winning the 2024 election from Chikhali as a Bharatiya Janata Party candidate (WON). The latest record places Shweta Mahale in Maharashtra with the Bharatiya Janata Party ticket for Chikhali.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d24eb3b7-6f6b-4965-bd9f-1aa9c1bdef9b",
+    "name": "Manoj Kayande",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sindkhed Raja",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sindkhed Raja",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Manoj Kayande is a Maharashtra leader and Member of the Legislative Assembly from Sindkhed Raja. The latest available result shows Manoj Kayande winning the 2024 election from Sindkhed Raja as a Nationalist Congress Party candidate (WON). The latest record places Manoj Kayande in Maharashtra with the Nationalist Congress Party ticket for Sindkhed Raja.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "7f4c5717-c9ea-4d6c-8c68-c6b774111cf2",
+    "name": "Siddharth Kharat",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mehkar (SC)",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mehkar (SC)",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Siddharth Kharat is a Maharashtra leader and Member of the Legislative Assembly from Mehkar (SC). The latest available result shows Siddharth Kharat winning the 2024 election from Mehkar (SC) as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Siddharth Kharat in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Mehkar (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "52c77bfe-7b50-4931-a427-179d4057a955",
+    "name": "Akash Fundkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Khamgaon",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Khamgaon",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Akash Fundkar is a Maharashtra leader and Member of the Legislative Assembly from Khamgaon. The latest available result shows Akash Fundkar winning the 2024 election from Khamgaon as a Bharatiya Janata Party candidate (WON). The latest record places Akash Fundkar in Maharashtra with the Bharatiya Janata Party ticket for Khamgaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1d9f578e-498c-47b8-a315-38361188605d",
+    "name": "Sanjay Kute",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jalgaon (Jamod)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jalgaon (Jamod)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Kute is a Maharashtra leader and Member of the Legislative Assembly from Jalgaon (Jamod). The latest available result shows Sanjay Kute winning the 2024 election from Jalgaon (Jamod) as a Bharatiya Janata Party candidate (WON). The latest record places Sanjay Kute in Maharashtra with the Bharatiya Janata Party ticket for Jalgaon (Jamod).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "aaacc0e6-ae7c-437b-ac4b-432c4e37100e",
+    "name": "Prakash Bharsakle",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Akot",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Akot",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Prakash Bharsakle is a Maharashtra leader and Member of the Legislative Assembly from Akot. The latest available result shows Prakash Bharsakle winning the 2024 election from Akot as a Bharatiya Janata Party candidate (WON). The latest record places Prakash Bharsakle in Maharashtra with the Bharatiya Janata Party ticket for Akot.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "480c3c66-a621-47d4-9e5e-cd6acc810561",
+    "name": "Nitin Deshmukh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Balapur",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Balapur",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Nitin Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Balapur. The latest available result shows Nitin Deshmukh winning the 2024 election from Balapur as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Nitin Deshmukh in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Balapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ccda760b-d974-41c9-a0bf-da0911a77ca7",
+    "name": "Sajid Khan Pathan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Akola West",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Akola West",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sajid Khan Pathan is a Maharashtra leader and Member of the Legislative Assembly from Akola West. The latest available result shows Sajid Khan Pathan winning the 2024 election from Akola West as a Indian National Congress candidate (WON). The latest record places Sajid Khan Pathan in Maharashtra with the Indian National Congress ticket for Akola West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6325c980-1ba3-4798-9592-c8681d3fce61",
+    "name": "Randhir Savarkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Akola East",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Akola East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Randhir Savarkar is a Maharashtra leader and Member of the Legislative Assembly from Akola East. The latest available result shows Randhir Savarkar winning the 2024 election from Akola East as a Bharatiya Janata Party candidate (WON). The latest record places Randhir Savarkar in Maharashtra with the Bharatiya Janata Party ticket for Akola East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b3a6bd4c-8f26-4c66-b994-58658cbd2ba0",
+    "name": "Harish Pimple",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Murtizapur (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Murtizapur (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Harish Pimple is a Maharashtra leader and Member of the Legislative Assembly from Murtizapur (SC). The latest available result shows Harish Pimple winning the 2024 election from Murtizapur (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Harish Pimple in Maharashtra with the Bharatiya Janata Party ticket for Murtizapur (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "e8f9ddf4-38a8-46fb-87dc-738df12685d3",
+    "name": "Amit Zanak",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Risod",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Risod",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Amit Zanak is a Maharashtra leader and Member of the Legislative Assembly from Risod. The latest available result shows Amit Zanak winning the 2024 election from Risod as a Indian National Congress candidate (WON). The latest record places Amit Zanak in Maharashtra with the Indian National Congress ticket for Risod.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "062ad0a3-af7a-419f-a9b6-44221c032ea6",
+    "name": "Shyam Khode",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Washim (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Washim (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shyam Khode is a Maharashtra leader and Member of the Legislative Assembly from Washim (SC). The latest available result shows Shyam Khode winning the 2024 election from Washim (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Shyam Khode in Maharashtra with the Bharatiya Janata Party ticket for Washim (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "cf9e3d15-140c-4033-872e-e0b156061740",
+    "name": "Sai Prakash Dahake",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Karanja",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Karanja",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sai Prakash Dahake is a Maharashtra leader and Member of the Legislative Assembly from Karanja. The latest available result shows Sai Prakash Dahake winning the 2024 election from Karanja as a Bharatiya Janata Party candidate (WON). The latest record places Sai Prakash Dahake in Maharashtra with the Bharatiya Janata Party ticket for Karanja.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8f26f46e-befa-402a-89c5-51dc78508d32",
+    "name": "Pratap Adsad",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dhamangaon Railway",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dhamangaon Railway",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Pratap Adsad is a Maharashtra leader and Member of the Legislative Assembly from Dhamangaon Railway. The latest available result shows Pratap Adsad winning the 2024 election from Dhamangaon Railway as a Bharatiya Janata Party candidate (WON). The latest record places Pratap Adsad in Maharashtra with the Bharatiya Janata Party ticket for Dhamangaon Railway.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ade608c0-9f19-45e1-9aed-0fa72f7c3b32",
+    "name": "Ravi Rana",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Badnera",
+    "party": "Rashtriya Yuva Swabhiman Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Badnera",
+          "party": "Rashtriya Yuva Swabhiman Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ravi Rana is a Maharashtra leader and Member of the Legislative Assembly from Badnera. The latest available result shows Ravi Rana winning the 2024 election from Badnera as a Rashtriya Yuva Swabhiman Party candidate (WON). The latest record places Ravi Rana in Maharashtra with the Rashtriya Yuva Swabhiman Party ticket for Badnera.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "91fc4c14-6e10-4273-a58f-6d8bd4b1e0fc",
+    "name": "Sulbha Khodke",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Amravati",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Amravati",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sulbha Khodke is a Maharashtra leader and Member of the Legislative Assembly from Amravati. The latest available result shows Sulbha Khodke winning the 2024 election from Amravati as a Nationalist Congress Party candidate (WON). The latest record places Sulbha Khodke in Maharashtra with the Nationalist Congress Party ticket for Amravati.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "86954473-b2bb-43a6-9a61-d10a09e9086f",
+    "name": "Rajesh Wankhade",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Teosa",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Teosa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajesh Wankhade is a Maharashtra leader and Member of the Legislative Assembly from Teosa. The latest available result shows Rajesh Wankhade winning the 2024 election from Teosa as a Bharatiya Janata Party candidate (WON). The latest record places Rajesh Wankhade in Maharashtra with the Bharatiya Janata Party ticket for Teosa.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2f245131-2667-4f4c-a250-fddae4e454a0",
+    "name": "Gajanan Lawate",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Daryapur (SC)",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Daryapur (SC)",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Gajanan Lawate is a Maharashtra leader and Member of the Legislative Assembly from Daryapur (SC). The latest available result shows Gajanan Lawate winning the 2024 election from Daryapur (SC) as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Gajanan Lawate in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Daryapur (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "7e98130d-dd35-49ff-aec1-26ddcc36a892",
+    "name": "Kewalram Kale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Melghat (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Melghat (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kewalram Kale is a Maharashtra leader and Member of the Legislative Assembly from Melghat (ST). The latest available result shows Kewalram Kale winning the 2024 election from Melghat (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Kewalram Kale in Maharashtra with the Bharatiya Janata Party ticket for Melghat (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6610c09a-d3cb-496e-bdeb-c2d94f0dec05",
+    "name": "Pawan Tayde",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Achalpur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Achalpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Pawan Tayde is a Maharashtra leader and Member of the Legislative Assembly from Achalpur. The latest available result shows Pawan Tayde winning the 2024 election from Achalpur as a Bharatiya Janata Party candidate (WON). The latest record places Pawan Tayde in Maharashtra with the Bharatiya Janata Party ticket for Achalpur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "16b1ab0e-56ca-48b9-972c-69970986cc58",
+    "name": "Chandu Yawalkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Morshi",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Morshi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chandu Yawalkar is a Maharashtra leader and Member of the Legislative Assembly from Morshi. The latest available result shows Chandu Yawalkar winning the 2024 election from Morshi as a Bharatiya Janata Party candidate (WON). The latest record places Chandu Yawalkar in Maharashtra with the Bharatiya Janata Party ticket for Morshi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6f6d06bf-9597-4741-9449-dd7b4a1c4807",
+    "name": "Sumit Wankhede",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Arvi",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Arvi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sumit Wankhede is a Maharashtra leader and Member of the Legislative Assembly from Arvi. The latest available result shows Sumit Wankhede winning the 2024 election from Arvi as a Bharatiya Janata Party candidate (WON). The latest record places Sumit Wankhede in Maharashtra with the Bharatiya Janata Party ticket for Arvi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4eac77d3-c087-41c7-a3c5-468a0d7dcef9",
+    "name": "Rajesh Bakane",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Deoli",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Deoli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajesh Bakane is a Maharashtra leader and Member of the Legislative Assembly from Deoli. The latest available result shows Rajesh Bakane winning the 2024 election from Deoli as a Bharatiya Janata Party candidate (WON). The latest record places Rajesh Bakane in Maharashtra with the Bharatiya Janata Party ticket for Deoli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a2755057-3076-45ee-8956-9d7a2331caf9",
+    "name": "Samir Kunawar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Hinganghat",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Hinganghat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Samir Kunawar is a Maharashtra leader and Member of the Legislative Assembly from Hinganghat. The latest available result shows Samir Kunawar winning the 2024 election from Hinganghat as a Bharatiya Janata Party candidate (WON). The latest record places Samir Kunawar in Maharashtra with the Bharatiya Janata Party ticket for Hinganghat.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d857ecf9-0b16-41da-ac87-9685bdb32dab",
+    "name": "Pankaj Bhoyar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Wardha",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Wardha",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Pankaj Bhoyar is a Maharashtra leader and Member of the Legislative Assembly from Wardha. The latest available result shows Pankaj Bhoyar winning the 2024 election from Wardha as a Bharatiya Janata Party candidate (WON). The latest record places Pankaj Bhoyar in Maharashtra with the Bharatiya Janata Party ticket for Wardha.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0f812c2b-d16e-45f8-bf4d-28f13657e94e",
+    "name": "Charansing Thakur",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Katol",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Katol",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Charansing Thakur is a Maharashtra leader and Member of the Legislative Assembly from Katol. The latest available result shows Charansing Thakur winning the 2024 election from Katol as a Bharatiya Janata Party candidate (WON). The latest record places Charansing Thakur in Maharashtra with the Bharatiya Janata Party ticket for Katol.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a4ad3e5b-111c-4c71-911e-a15d8bf73d6c",
+    "name": "Ashish Deshmukh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Savner",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Savner",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ashish Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Savner. The latest available result shows Ashish Deshmukh winning the 2024 election from Savner as a Bharatiya Janata Party candidate (WON). The latest record places Ashish Deshmukh in Maharashtra with the Bharatiya Janata Party ticket for Savner.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2ebc46da-e137-48fd-8bc8-650931def859",
+    "name": "Sameer Meghe",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Hingna",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Hingna",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sameer Meghe is a Maharashtra leader and Member of the Legislative Assembly from Hingna. The latest available result shows Sameer Meghe winning the 2024 election from Hingna as a Bharatiya Janata Party candidate (WON). The latest record places Sameer Meghe in Maharashtra with the Bharatiya Janata Party ticket for Hingna.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2d73c63b-8f4a-4162-bbfd-8dd710e6a0fe",
+    "name": "Sanjay Meshram",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Umred (SC)",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Umred (SC)",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Meshram is a Maharashtra leader and Member of the Legislative Assembly from Umred (SC). The latest available result shows Sanjay Meshram winning the 2024 election from Umred (SC) as a Indian National Congress candidate (WON). The latest record places Sanjay Meshram in Maharashtra with the Indian National Congress ticket for Umred (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0c5c0737-ff4f-488d-8c4d-bd4535a01aca",
+    "name": "Devendra Fadnavis",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nagpur South West",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nagpur South West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Devendra Fadnavis is a Maharashtra leader and Member of the Legislative Assembly from Nagpur South West. The latest available result shows Devendra Fadnavis winning the 2024 election from Nagpur South West as a Bharatiya Janata Party candidate (WON). The latest record places Devendra Fadnavis in Maharashtra with the Bharatiya Janata Party ticket for Nagpur South West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d8a14d5b-da7b-47e8-8797-5ab90c178c64",
+    "name": "Mohan Mate",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nagpur South",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nagpur South",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mohan Mate is a Maharashtra leader and Member of the Legislative Assembly from Nagpur South. The latest available result shows Mohan Mate winning the 2024 election from Nagpur South as a Bharatiya Janata Party candidate (WON). The latest record places Mohan Mate in Maharashtra with the Bharatiya Janata Party ticket for Nagpur South.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "3496f4c0-d706-4460-a311-17712ab4fc0b",
+    "name": "Krishna Khopde",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nagpur East",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nagpur East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Krishna Khopde is a Maharashtra leader and Member of the Legislative Assembly from Nagpur East. The latest available result shows Krishna Khopde winning the 2024 election from Nagpur East as a Bharatiya Janata Party candidate (WON). The latest record places Krishna Khopde in Maharashtra with the Bharatiya Janata Party ticket for Nagpur East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "fcd93e24-8be2-4374-90b0-ed8a0727d22b",
+    "name": "Pravin Datke",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nagpur Central",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nagpur Central",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Pravin Datke is a Maharashtra leader and Member of the Legislative Assembly from Nagpur Central. The latest available result shows Pravin Datke winning the 2024 election from Nagpur Central as a Bharatiya Janata Party candidate (WON). The latest record places Pravin Datke in Maharashtra with the Bharatiya Janata Party ticket for Nagpur Central.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "55532d74-f958-4675-af20-8cd1d1d82ac8",
+    "name": "Vikas Thakre",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nagpur West",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nagpur West",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vikas Thakre is a Maharashtra leader and Member of the Legislative Assembly from Nagpur West. The latest available result shows Vikas Thakre winning the 2024 election from Nagpur West as a Indian National Congress candidate (WON). The latest record places Vikas Thakre in Maharashtra with the Indian National Congress ticket for Nagpur West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9beca8da-62cc-4f7b-9659-58df13029477",
+    "name": "Nitin Raut",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nagpur North (SC)",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nagpur North (SC)",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Nitin Raut is a Maharashtra leader and Member of the Legislative Assembly from Nagpur North (SC). The latest available result shows Nitin Raut winning the 2024 election from Nagpur North (SC) as a Indian National Congress candidate (WON). The latest record places Nitin Raut in Maharashtra with the Indian National Congress ticket for Nagpur North (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "e1f48877-232b-4de0-a5e8-89b7342c5895",
+    "name": "Chandrashekhar Bawankule",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kamthi",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kamthi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chandrashekhar Bawankule is a Maharashtra leader and Member of the Legislative Assembly from Kamthi. The latest available result shows Chandrashekhar Bawankule winning the 2024 election from Kamthi as a Bharatiya Janata Party candidate (WON). The latest record places Chandrashekhar Bawankule in Maharashtra with the Bharatiya Janata Party ticket for Kamthi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ac4cd4ca-4497-4165-8573-7e8ff3fe85da",
+    "name": "Ashish Jaiswal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ramtek",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ramtek",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ashish Jaiswal is a Maharashtra leader and Member of the Legislative Assembly from Ramtek. The latest available result shows Ashish Jaiswal winning the 2024 election from Ramtek as a Shiv Sena candidate (WON). The latest record places Ashish Jaiswal in Maharashtra with the Shiv Sena ticket for Ramtek.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8209179c-15b3-4f83-bde7-975d1cd71244",
+    "name": "Raju Karemore",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Tumsar",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Tumsar",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Raju Karemore is a Maharashtra leader and Member of the Legislative Assembly from Tumsar. The latest available result shows Raju Karemore winning the 2024 election from Tumsar as a Nationalist Congress Party candidate (WON). The latest record places Raju Karemore in Maharashtra with the Nationalist Congress Party ticket for Tumsar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "98f3eb4d-613d-4cc3-8f2b-b19d49251f83",
+    "name": "Narendra Bhondekar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhandara (SC)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhandara (SC)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Narendra Bhondekar is a Maharashtra leader and Member of the Legislative Assembly from Bhandara (SC). The latest available result shows Narendra Bhondekar winning the 2024 election from Bhandara (SC) as a Shiv Sena candidate (WON). The latest record places Narendra Bhondekar in Maharashtra with the Shiv Sena ticket for Bhandara (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9dc79a11-943a-49f6-ac18-c442ccedd7ec",
+    "name": "Nana Patole",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sakoli",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sakoli",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Nana Patole is a Maharashtra leader and Member of the Legislative Assembly from Sakoli. The latest available result shows Nana Patole winning the 2024 election from Sakoli as a Indian National Congress candidate (WON). The latest record places Nana Patole in Maharashtra with the Indian National Congress ticket for Sakoli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "cc3d616c-7a1a-4670-8714-29710ff31753",
+    "name": "Rajkumar Badole",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Arjuni-Morgaon (SC)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Arjuni-Morgaon (SC)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajkumar Badole is a Maharashtra leader and Member of the Legislative Assembly from Arjuni-Morgaon (SC). The latest available result shows Rajkumar Badole winning the 2024 election from Arjuni-Morgaon (SC) as a Nationalist Congress Party candidate (WON). The latest record places Rajkumar Badole in Maharashtra with the Nationalist Congress Party ticket for Arjuni-Morgaon (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5389745c-65a0-4044-a531-cadb5acf5774",
+    "name": "Vijay Rahangdale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Tirora",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Tirora",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vijay Rahangdale is a Maharashtra leader and Member of the Legislative Assembly from Tirora. The latest available result shows Vijay Rahangdale winning the 2024 election from Tirora as a Bharatiya Janata Party candidate (WON). The latest record places Vijay Rahangdale in Maharashtra with the Bharatiya Janata Party ticket for Tirora.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "f5d89206-97fa-41a4-b0f8-ada018f301c8",
+    "name": "Vinod Agrawal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Gondiya",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Gondiya",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vinod Agrawal is a Maharashtra leader and Member of the Legislative Assembly from Gondiya. The latest available result shows Vinod Agrawal winning the 2024 election from Gondiya as a Bharatiya Janata Party candidate (WON). The latest record places Vinod Agrawal in Maharashtra with the Bharatiya Janata Party ticket for Gondiya.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d07f54ae-8d82-42da-a9ee-d61e6fbb023a",
+    "name": "Sanjay Puram",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Amgaon (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Amgaon (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Puram is a Maharashtra leader and Member of the Legislative Assembly from Amgaon (ST). The latest available result shows Sanjay Puram winning the 2024 election from Amgaon (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Sanjay Puram in Maharashtra with the Bharatiya Janata Party ticket for Amgaon (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "3d64e06e-3ff8-4e4c-9084-f3383072c5b8",
+    "name": "Ramdas Masram",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Armori (ST)",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Armori (ST)",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ramdas Masram is a Maharashtra leader and Member of the Legislative Assembly from Armori (ST). The latest available result shows Ramdas Masram winning the 2024 election from Armori (ST) as a Indian National Congress candidate (WON). The latest record places Ramdas Masram in Maharashtra with the Indian National Congress ticket for Armori (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "df810537-5d8b-453d-9718-a48fd4003736",
+    "name": "Milind Ramji Narote",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Gadchiroli (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Gadchiroli (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Milind Ramji Narote is a Maharashtra leader and Member of the Legislative Assembly from Gadchiroli (ST). The latest available result shows Milind Ramji Narote winning the 2024 election from Gadchiroli (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Milind Ramji Narote in Maharashtra with the Bharatiya Janata Party ticket for Gadchiroli (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ec5aec48-e172-40e3-bc91-7abfdfc455c8",
+    "name": "Dharamrao Baba Atram",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Aheri (ST)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Aheri (ST)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dharamrao Baba Atram is a Maharashtra leader and Member of the Legislative Assembly from Aheri (ST). The latest available result shows Dharamrao Baba Atram winning the 2024 election from Aheri (ST) as a Nationalist Congress Party candidate (WON). The latest record places Dharamrao Baba Atram in Maharashtra with the Nationalist Congress Party ticket for Aheri (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "804332e5-c25a-416c-99a4-76629f0f5f61",
+    "name": "Deorao Bhongle",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Rajura",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Rajura",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Deorao Bhongle is a Maharashtra leader and Member of the Legislative Assembly from Rajura. The latest available result shows Deorao Bhongle winning the 2024 election from Rajura as a Bharatiya Janata Party candidate (WON). The latest record places Deorao Bhongle in Maharashtra with the Bharatiya Janata Party ticket for Rajura.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "aa5b6547-f6e9-48f3-b3fd-ad831b806db7",
+    "name": "Kishor Jorgewar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chandrapur (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chandrapur (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kishor Jorgewar is a Maharashtra leader and Member of the Legislative Assembly from Chandrapur (SC). The latest available result shows Kishor Jorgewar winning the 2024 election from Chandrapur (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Kishor Jorgewar in Maharashtra with the Bharatiya Janata Party ticket for Chandrapur (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b8e8cbeb-6eb1-4263-bd9a-b841a50d0828",
+    "name": "Sudhir Mungantiwar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ballarpur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ballarpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sudhir Mungantiwar is a Maharashtra leader and Member of the Legislative Assembly from Ballarpur. The latest available result shows Sudhir Mungantiwar winning the 2024 election from Ballarpur as a Bharatiya Janata Party candidate (WON). The latest record places Sudhir Mungantiwar in Maharashtra with the Bharatiya Janata Party ticket for Ballarpur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0105a62e-3f12-441a-80b9-1ce87db3c017",
+    "name": "Vijay Wadettiwar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bramhapuri",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bramhapuri",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vijay Wadettiwar is a Maharashtra leader and Member of the Legislative Assembly from Bramhapuri. The latest available result shows Vijay Wadettiwar winning the 2024 election from Bramhapuri as a Indian National Congress candidate (WON). The latest record places Vijay Wadettiwar in Maharashtra with the Indian National Congress ticket for Bramhapuri.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "af63c187-2fcd-420d-8629-f6d3150b2ea2",
+    "name": "Bunty Bhangdiya",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chimur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chimur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Bunty Bhangdiya is a Maharashtra leader and Member of the Legislative Assembly from Chimur. The latest available result shows Bunty Bhangdiya winning the 2024 election from Chimur as a Bharatiya Janata Party candidate (WON). The latest record places Bunty Bhangdiya in Maharashtra with the Bharatiya Janata Party ticket for Chimur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "04f51e82-9ee2-4cae-a9c0-ad4f54b546fe",
+    "name": "Karan Deotale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Warora",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Warora",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Karan Deotale is a Maharashtra leader and Member of the Legislative Assembly from Warora. The latest available result shows Karan Deotale winning the 2024 election from Warora as a Bharatiya Janata Party candidate (WON). The latest record places Karan Deotale in Maharashtra with the Bharatiya Janata Party ticket for Warora.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ff39a6b3-42ff-472b-9617-de4ed3b9ea5f",
+    "name": "Sanjay Derkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Wani",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Wani",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Derkar is a Maharashtra leader and Member of the Legislative Assembly from Wani. The latest available result shows Sanjay Derkar winning the 2024 election from Wani as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Sanjay Derkar in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Wani.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b71bd0ca-a7a2-4224-8fc6-6a79d114fa9c",
+    "name": "Ashok Uike",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ralegaon (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ralegaon (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ashok Uike is a Maharashtra leader and Member of the Legislative Assembly from Ralegaon (ST). The latest available result shows Ashok Uike winning the 2024 election from Ralegaon (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Ashok Uike in Maharashtra with the Bharatiya Janata Party ticket for Ralegaon (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d7da607e-fa59-4180-ad47-dd434928533a",
+    "name": "Balasaheb Mangulkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Yavatmal",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Yavatmal",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Balasaheb Mangulkar is a Maharashtra leader and Member of the Legislative Assembly from Yavatmal. The latest available result shows Balasaheb Mangulkar winning the 2024 election from Yavatmal as a Indian National Congress candidate (WON). The latest record places Balasaheb Mangulkar in Maharashtra with the Indian National Congress ticket for Yavatmal.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b8310cff-4747-4882-8275-3b3948b831e3",
+    "name": "Sanjay Rathod",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Digras",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Digras",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Rathod is a Maharashtra leader and Member of the Legislative Assembly from Digras. The latest available result shows Sanjay Rathod winning the 2024 election from Digras as a Shiv Sena candidate (WON). The latest record places Sanjay Rathod in Maharashtra with the Shiv Sena ticket for Digras.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "23f8d78d-44c8-4421-b423-61549fe46a9f",
+    "name": "Raju Todsam",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Arni (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Arni (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Raju Todsam is a Maharashtra leader and Member of the Legislative Assembly from Arni (ST). The latest available result shows Raju Todsam winning the 2024 election from Arni (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Raju Todsam in Maharashtra with the Bharatiya Janata Party ticket for Arni (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "52ff38dd-555f-487e-93d6-8a8b6590f01b",
+    "name": "Indranil Naik",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Pusad",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Pusad",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Indranil Naik is a Maharashtra leader and Member of the Legislative Assembly from Pusad. The latest available result shows Indranil Naik winning the 2024 election from Pusad as a Nationalist Congress Party candidate (WON). The latest record places Indranil Naik in Maharashtra with the Nationalist Congress Party ticket for Pusad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "740a4b18-4c25-4a06-8945-4207b8a85f66",
+    "name": "Kisan Wankhede",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Umarkhed (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Umarkhed (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kisan Wankhede is a Maharashtra leader and Member of the Legislative Assembly from Umarkhed (SC). The latest available result shows Kisan Wankhede winning the 2024 election from Umarkhed (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Kisan Wankhede in Maharashtra with the Bharatiya Janata Party ticket for Umarkhed (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ff2c5bf5-83e2-41e9-aafb-5e2ad81ae09c",
+    "name": "Bhimrao Keram",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kinwat",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kinwat",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Bhimrao Keram is a Maharashtra leader and Member of the Legislative Assembly from Kinwat. The latest available result shows Bhimrao Keram winning the 2024 election from Kinwat as a Bharatiya Janata Party candidate (WON). The latest record places Bhimrao Keram in Maharashtra with the Bharatiya Janata Party ticket for Kinwat.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a7078df2-a8d6-4374-aa1c-2fa02ff81d62",
+    "name": "Baburao Kadam",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Hadgaon",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Hadgaon",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Baburao Kadam is a Maharashtra leader and Member of the Legislative Assembly from Hadgaon. The latest available result shows Baburao Kadam winning the 2024 election from Hadgaon as a Shiv Sena candidate (WON). The latest record places Baburao Kadam in Maharashtra with the Shiv Sena ticket for Hadgaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "dda4e9fb-6670-4a03-bdf4-62b1922b8c68",
+    "name": "Sreejaya Chavan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhokar",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhokar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sreejaya Chavan is a Maharashtra leader and Member of the Legislative Assembly from Bhokar. The latest available result shows Sreejaya Chavan winning the 2024 election from Bhokar as a Bharatiya Janata Party candidate (WON). The latest record places Sreejaya Chavan in Maharashtra with the Bharatiya Janata Party ticket for Bhokar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "cd070587-6224-4c49-a82f-8f138a34ca92",
+    "name": "Balaji Kalyankar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nanded North",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nanded North",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Balaji Kalyankar is a Maharashtra leader and Member of the Legislative Assembly from Nanded North. The latest available result shows Balaji Kalyankar winning the 2024 election from Nanded North as a Shiv Sena candidate (WON). The latest record places Balaji Kalyankar in Maharashtra with the Shiv Sena ticket for Nanded North.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a62f78e4-77be-4764-94f2-10d2119cb707",
+    "name": "Anand Tidke",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nanded South",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nanded South",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Anand Tidke is a Maharashtra leader and Member of the Legislative Assembly from Nanded South. The latest available result shows Anand Tidke winning the 2024 election from Nanded South as a Shiv Sena candidate (WON). The latest record places Anand Tidke in Maharashtra with the Shiv Sena ticket for Nanded South.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "637ef840-3f8a-4af7-86d7-b947586a468c",
+    "name": "Prataprao Chikhalikar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Loha",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Loha",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Prataprao Chikhalikar is a Maharashtra leader and Member of the Legislative Assembly from Loha. The latest available result shows Prataprao Chikhalikar winning the 2024 election from Loha as a Nationalist Congress Party candidate (WON). The latest record places Prataprao Chikhalikar in Maharashtra with the Nationalist Congress Party ticket for Loha.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2d2235b3-c1f4-4f2d-86c8-5dc08d441176",
+    "name": "Rajesh Pawar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Naigaon",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Naigaon",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajesh Pawar is a Maharashtra leader and Member of the Legislative Assembly from Naigaon. The latest available result shows Rajesh Pawar winning the 2024 election from Naigaon as a Bharatiya Janata Party candidate (WON). The latest record places Rajesh Pawar in Maharashtra with the Bharatiya Janata Party ticket for Naigaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "364d714f-5298-487b-84a8-782991694340",
+    "name": "Jitesh Antapurkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Deglur (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Deglur (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Jitesh Antapurkar is a Maharashtra leader and Member of the Legislative Assembly from Deglur (SC). The latest available result shows Jitesh Antapurkar winning the 2024 election from Deglur (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Jitesh Antapurkar in Maharashtra with the Bharatiya Janata Party ticket for Deglur (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "52ae45fe-cb7f-43c3-9d1e-23911e490c61",
+    "name": "Tushar Rathod",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mukhed",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mukhed",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Tushar Rathod is a Maharashtra leader and Member of the Legislative Assembly from Mukhed. The latest available result shows Tushar Rathod winning the 2024 election from Mukhed as a Bharatiya Janata Party candidate (WON). The latest record places Tushar Rathod in Maharashtra with the Bharatiya Janata Party ticket for Mukhed.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a34f5652-6ea8-4ab0-b7ef-20cd808602a3",
+    "name": "Chandrakant Nawghare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Basmath",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Basmath",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chandrakant Nawghare is a Maharashtra leader and Member of the Legislative Assembly from Basmath. The latest available result shows Chandrakant Nawghare winning the 2024 election from Basmath as a Nationalist Congress Party candidate (WON). The latest record places Chandrakant Nawghare in Maharashtra with the Nationalist Congress Party ticket for Basmath.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "55ec0882-070e-4a3a-bb8d-703adb386012",
+    "name": "Santosh Bangar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kalamnuri",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kalamnuri",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Santosh Bangar is a Maharashtra leader and Member of the Legislative Assembly from Kalamnuri. The latest available result shows Santosh Bangar winning the 2024 election from Kalamnuri as a Shiv Sena candidate (WON). The latest record places Santosh Bangar in Maharashtra with the Shiv Sena ticket for Kalamnuri.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "989e2dd1-a817-4887-a27f-ac0dd2d3852c",
+    "name": "Tanaji Mutkule",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Hingoli",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Hingoli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Tanaji Mutkule is a Maharashtra leader and Member of the Legislative Assembly from Hingoli. The latest available result shows Tanaji Mutkule winning the 2024 election from Hingoli as a Bharatiya Janata Party candidate (WON). The latest record places Tanaji Mutkule in Maharashtra with the Bharatiya Janata Party ticket for Hingoli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4d2ef0e4-45ee-41ff-8417-5bd493b89a29",
+    "name": "Meghna Bordikar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jintur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jintur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Meghna Bordikar is a Maharashtra leader and Member of the Legislative Assembly from Jintur. The latest available result shows Meghna Bordikar winning the 2024 election from Jintur as a Bharatiya Janata Party candidate (WON). The latest record places Meghna Bordikar in Maharashtra with the Bharatiya Janata Party ticket for Jintur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "be5e344f-52e6-4dfe-9473-b1bc30dfe35d",
+    "name": "Rahul Vedprakash Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Parbhani",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Parbhani",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rahul Vedprakash Patil is a Maharashtra leader and Member of the Legislative Assembly from Parbhani. The latest available result shows Rahul Vedprakash Patil winning the 2024 election from Parbhani as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Rahul Vedprakash Patil in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Parbhani.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "006107d3-f53b-4a25-9035-f67d914e1329",
+    "name": "Ratnakar Gutte",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Gangakhed",
+    "party": "Rashtriya Samaj Paksha",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Gangakhed",
+          "party": "Rashtriya Samaj Paksha",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ratnakar Gutte is a Maharashtra leader and Member of the Legislative Assembly from Gangakhed. The latest available result shows Ratnakar Gutte winning the 2024 election from Gangakhed as a Rashtriya Samaj Paksha candidate (WON). The latest record places Ratnakar Gutte in Maharashtra with the Rashtriya Samaj Paksha ticket for Gangakhed.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "49fdfdf6-25d2-4973-8cfa-d7ada15c3b7b",
+    "name": "Rajesh Vitekar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Pathri",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Pathri",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajesh Vitekar is a Maharashtra leader and Member of the Legislative Assembly from Pathri. The latest available result shows Rajesh Vitekar winning the 2024 election from Pathri as a Nationalist Congress Party candidate (WON). The latest record places Rajesh Vitekar in Maharashtra with the Nationalist Congress Party ticket for Pathri.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b0cc05f4-a10a-43cc-a56b-679deef5f448",
+    "name": "Babanrao Lonikar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Partur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Partur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Babanrao Lonikar is a Maharashtra leader and Member of the Legislative Assembly from Partur. The latest available result shows Babanrao Lonikar winning the 2024 election from Partur as a Bharatiya Janata Party candidate (WON). The latest record places Babanrao Lonikar in Maharashtra with the Bharatiya Janata Party ticket for Partur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "27ae7339-7190-420c-8508-48d89c5d33bb",
+    "name": "Hikmat Udhan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ghansawangi",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ghansawangi",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Hikmat Udhan is a Maharashtra leader and Member of the Legislative Assembly from Ghansawangi. The latest available result shows Hikmat Udhan winning the 2024 election from Ghansawangi as a Shiv Sena candidate (WON). The latest record places Hikmat Udhan in Maharashtra with the Shiv Sena ticket for Ghansawangi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "70dc075f-bbef-4b9f-a848-765557e9ac82",
+    "name": "Arjun Khotkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jalna",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jalna",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Arjun Khotkar is a Maharashtra leader and Member of the Legislative Assembly from Jalna. The latest available result shows Arjun Khotkar winning the 2024 election from Jalna as a Shiv Sena candidate (WON). The latest record places Arjun Khotkar in Maharashtra with the Shiv Sena ticket for Jalna.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "855ff9dd-92ec-4731-afef-da11c492649b",
+    "name": "Narayan Kuche",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Badnapur (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Badnapur (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Narayan Kuche is a Maharashtra leader and Member of the Legislative Assembly from Badnapur (SC). The latest available result shows Narayan Kuche winning the 2024 election from Badnapur (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Narayan Kuche in Maharashtra with the Bharatiya Janata Party ticket for Badnapur (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c66c7d92-2cad-46c1-bb11-0de2b7a1fc34",
+    "name": "Santosh Danve",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhokardan",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhokardan",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Santosh Danve is a Maharashtra leader and Member of the Legislative Assembly from Bhokardan. The latest available result shows Santosh Danve winning the 2024 election from Bhokardan as a Bharatiya Janata Party candidate (WON). The latest record places Santosh Danve in Maharashtra with the Bharatiya Janata Party ticket for Bhokardan.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "da456633-7858-433b-b423-f81c1d232e19",
+    "name": "Abdul Sattar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sillod",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sillod",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Abdul Sattar is a Maharashtra leader and Member of the Legislative Assembly from Sillod. The latest available result shows Abdul Sattar winning the 2024 election from Sillod as a Shiv Sena candidate (WON). The latest record places Abdul Sattar in Maharashtra with the Shiv Sena ticket for Sillod.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "85568ff1-8ad3-4b51-b1be-cab45bb2036b",
+    "name": "Sanjana Jadhav",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kannad",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kannad",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjana Jadhav is a Maharashtra leader and Member of the Legislative Assembly from Kannad. The latest available result shows Sanjana Jadhav winning the 2024 election from Kannad as a Shiv Sena candidate (WON). The latest record places Sanjana Jadhav in Maharashtra with the Shiv Sena ticket for Kannad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "97d3dd79-0bba-4805-b6e8-cca741f470f2",
+    "name": "Anuradha Chavan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Phulambri",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Phulambri",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Anuradha Chavan is a Maharashtra leader and Member of the Legislative Assembly from Phulambri. The latest available result shows Anuradha Chavan winning the 2024 election from Phulambri as a Bharatiya Janata Party candidate (WON). The latest record places Anuradha Chavan in Maharashtra with the Bharatiya Janata Party ticket for Phulambri.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ef6aa525-0809-42d6-be6d-d319404afd76",
+    "name": "Pradeep Jaiswal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Aurangabad Central",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Aurangabad Central",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Pradeep Jaiswal is a Maharashtra leader and Member of the Legislative Assembly from Aurangabad Central. The latest available result shows Pradeep Jaiswal winning the 2024 election from Aurangabad Central as a Shiv Sena candidate (WON). The latest record places Pradeep Jaiswal in Maharashtra with the Shiv Sena ticket for Aurangabad Central.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b55cc834-8385-4c24-812f-1444501b5e84",
+    "name": "Sanjay Shirsat",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Aurangabad West (SC)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Aurangabad West (SC)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Shirsat is a Maharashtra leader and Member of the Legislative Assembly from Aurangabad West (SC). The latest available result shows Sanjay Shirsat winning the 2024 election from Aurangabad West (SC) as a Shiv Sena candidate (WON). The latest record places Sanjay Shirsat in Maharashtra with the Shiv Sena ticket for Aurangabad West (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d9748bc8-357c-45bf-83fe-4ae0df7d13e5",
+    "name": "Atul Save",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Aurangabad East",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Aurangabad East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Atul Save is a Maharashtra leader and Member of the Legislative Assembly from Aurangabad East. The latest available result shows Atul Save winning the 2024 election from Aurangabad East as a Bharatiya Janata Party candidate (WON). The latest record places Atul Save in Maharashtra with the Bharatiya Janata Party ticket for Aurangabad East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "78fb9c33-458c-4ee8-b639-b3bf725e7e3b",
+    "name": "Vilas Bhumre",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Paithan",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Paithan",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vilas Bhumre is a Maharashtra leader and Member of the Legislative Assembly from Paithan. The latest available result shows Vilas Bhumre winning the 2024 election from Paithan as a Shiv Sena candidate (WON). The latest record places Vilas Bhumre in Maharashtra with the Shiv Sena ticket for Paithan.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ebeb5ce9-142e-4ad1-9d8f-66fce58fde8e",
+    "name": "Prashant Bamb",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Gangapur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Gangapur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Prashant Bamb is a Maharashtra leader and Member of the Legislative Assembly from Gangapur. The latest available result shows Prashant Bamb winning the 2024 election from Gangapur as a Bharatiya Janata Party candidate (WON). The latest record places Prashant Bamb in Maharashtra with the Bharatiya Janata Party ticket for Gangapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5fa747e9-aef8-46c8-a51e-b99c4baaca37",
+    "name": "Ramesh Bornare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vaijapur",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vaijapur",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ramesh Bornare is a Maharashtra leader and Member of the Legislative Assembly from Vaijapur. The latest available result shows Ramesh Bornare winning the 2024 election from Vaijapur as a Shiv Sena candidate (WON). The latest record places Ramesh Bornare in Maharashtra with the Shiv Sena ticket for Vaijapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "00a0815e-70a9-47f4-886c-96a0a4ec4c00",
+    "name": "Suhas Kande",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nandgaon",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nandgaon",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Suhas Kande is a Maharashtra leader and Member of the Legislative Assembly from Nandgaon. The latest available result shows Suhas Kande winning the 2024 election from Nandgaon as a Shiv Sena candidate (WON). The latest record places Suhas Kande in Maharashtra with the Shiv Sena ticket for Nandgaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5590998a-f076-4f17-8184-5e51a34a2ec5",
+    "name": "Ismail Abdul Khalique",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Malegaon Central",
+    "party": "All India Majlis-e-Ittehadul Muslimeen",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Malegaon Central",
+          "party": "All India Majlis-e-Ittehadul Muslimeen",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ismail Abdul Khalique is a Maharashtra leader and Member of the Legislative Assembly from Malegaon Central. The latest available result shows Ismail Abdul Khalique winning the 2024 election from Malegaon Central as a All India Majlis-e-Ittehadul Muslimeen candidate (WON). The latest record places Ismail Abdul Khalique in Maharashtra with the All India Majlis-e-Ittehadul Muslimeen ticket for Malegaon Central.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0d6a7771-79c2-4b2e-801f-b11d4e909d33",
+    "name": "Dadaji Bhuse",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Malegaon Outer",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Malegaon Outer",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dadaji Bhuse is a Maharashtra leader and Member of the Legislative Assembly from Malegaon Outer. The latest available result shows Dadaji Bhuse winning the 2024 election from Malegaon Outer as a Shiv Sena candidate (WON). The latest record places Dadaji Bhuse in Maharashtra with the Shiv Sena ticket for Malegaon Outer.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "be2a1cd1-355e-4af4-a54b-ab9985b06ba9",
+    "name": "Dilip Borse",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Baglan (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Baglan (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dilip Borse is a Maharashtra leader and Member of the Legislative Assembly from Baglan (ST). The latest available result shows Dilip Borse winning the 2024 election from Baglan (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Dilip Borse in Maharashtra with the Bharatiya Janata Party ticket for Baglan (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "dbf2234c-0f86-4186-91b3-e6f785a9e612",
+    "name": "Nitin Pawar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kalwan (ST)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kalwan (ST)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Nitin Pawar is a Maharashtra leader and Member of the Legislative Assembly from Kalwan (ST). The latest available result shows Nitin Pawar winning the 2024 election from Kalwan (ST) as a Nationalist Congress Party candidate (WON). The latest record places Nitin Pawar in Maharashtra with the Nationalist Congress Party ticket for Kalwan (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "37a8ad62-9f57-4e5d-ae91-7140fba2bb97",
+    "name": "Rahul Aher",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chandwad",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chandwad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rahul Aher is a Maharashtra leader and Member of the Legislative Assembly from Chandwad. The latest available result shows Rahul Aher winning the 2024 election from Chandwad as a Bharatiya Janata Party candidate (WON). The latest record places Rahul Aher in Maharashtra with the Bharatiya Janata Party ticket for Chandwad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "eab71c20-8b59-4f07-9cae-fc2b510fbe5f",
+    "name": "Chhagan Bhujbal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Yevla",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Yevla",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chhagan Bhujbal is a Maharashtra leader and Member of the Legislative Assembly from Yevla. The latest available result shows Chhagan Bhujbal winning the 2024 election from Yevla as a Nationalist Congress Party candidate (WON). The latest record places Chhagan Bhujbal in Maharashtra with the Nationalist Congress Party ticket for Yevla.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "02c8eea1-9bcd-47a8-9df1-7dcb9d55b9a7",
+    "name": "Manikrao Kokate",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sinnar",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sinnar",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Manikrao Kokate is a Maharashtra leader and Member of the Legislative Assembly from Sinnar. The latest available result shows Manikrao Kokate winning the 2024 election from Sinnar as a Nationalist Congress Party candidate (WON). The latest record places Manikrao Kokate in Maharashtra with the Nationalist Congress Party ticket for Sinnar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "aa60ca82-a6b8-4081-bf16-dc49be9744c0",
+    "name": "Diliprao Bankar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Niphad",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Niphad",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Diliprao Bankar is a Maharashtra leader and Member of the Legislative Assembly from Niphad. The latest available result shows Diliprao Bankar winning the 2024 election from Niphad as a Nationalist Congress Party candidate (WON). The latest record places Diliprao Bankar in Maharashtra with the Nationalist Congress Party ticket for Niphad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ee56a4a4-a6d2-41c3-86ad-3ee09f99abf8",
+    "name": "Narhari Zirwal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dindori (ST)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dindori (ST)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Narhari Zirwal is a Maharashtra leader and Member of the Legislative Assembly from Dindori (ST). The latest available result shows Narhari Zirwal winning the 2024 election from Dindori (ST) as a Nationalist Congress Party candidate (WON). The latest record places Narhari Zirwal in Maharashtra with the Nationalist Congress Party ticket for Dindori (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "72d7f741-6c8b-4ea5-808b-fb265d80ba55",
+    "name": "Rahul Dhikale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nashik East",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nashik East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rahul Dhikale is a Maharashtra leader and Member of the Legislative Assembly from Nashik East. The latest available result shows Rahul Dhikale winning the 2024 election from Nashik East as a Bharatiya Janata Party candidate (WON). The latest record places Rahul Dhikale in Maharashtra with the Bharatiya Janata Party ticket for Nashik East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d8f1f010-0b97-4ec7-b964-db6d79c56b58",
+    "name": "Devayani Farande",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nashik Central",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nashik Central",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Devayani Farande is a Maharashtra leader and Member of the Legislative Assembly from Nashik Central. The latest available result shows Devayani Farande winning the 2024 election from Nashik Central as a Bharatiya Janata Party candidate (WON). The latest record places Devayani Farande in Maharashtra with the Bharatiya Janata Party ticket for Nashik Central.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c0b0c26f-e75c-4ef3-9651-9bd316d12fa4",
+    "name": "Seema Hiray",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nashik West",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nashik West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Seema Hiray is a Maharashtra leader and Member of the Legislative Assembly from Nashik West. The latest available result shows Seema Hiray winning the 2024 election from Nashik West as a Bharatiya Janata Party candidate (WON). The latest record places Seema Hiray in Maharashtra with the Bharatiya Janata Party ticket for Nashik West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "52143046-2e72-41bb-8208-1516b035f119",
+    "name": "Saroj Ahire",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Deolali (SC)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Deolali (SC)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Saroj Ahire is a Maharashtra leader and Member of the Legislative Assembly from Deolali (SC). The latest available result shows Saroj Ahire winning the 2024 election from Deolali (SC) as a Nationalist Congress Party candidate (WON). The latest record places Saroj Ahire in Maharashtra with the Nationalist Congress Party ticket for Deolali (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5be4fa8c-2069-47aa-82db-51112d104a1e",
+    "name": "Hiraman Khoskar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Igatpuri (ST)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Igatpuri (ST)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Hiraman Khoskar is a Maharashtra leader and Member of the Legislative Assembly from Igatpuri (ST). The latest available result shows Hiraman Khoskar winning the 2024 election from Igatpuri (ST) as a Nationalist Congress Party candidate (WON). The latest record places Hiraman Khoskar in Maharashtra with the Nationalist Congress Party ticket for Igatpuri (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b3d65e30-6122-4200-9ad2-208560174157",
+    "name": "Vinod Nikole",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dahanu (ST)",
+    "party": "Communist Party of India (Marxist)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dahanu (ST)",
+          "party": "Communist Party of India (Marxist)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vinod Nikole is a Maharashtra leader and Member of the Legislative Assembly from Dahanu (ST). The latest available result shows Vinod Nikole winning the 2024 election from Dahanu (ST) as a Communist Party of India (Marxist) candidate (WON). The latest record places Vinod Nikole in Maharashtra with the Communist Party of India (Marxist) ticket for Dahanu (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ea1c57e5-7c81-4334-b711-37bf08a955f4",
+    "name": "Harishchandra Bhoye",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vikramgad (ST)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vikramgad (ST)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Harishchandra Bhoye is a Maharashtra leader and Member of the Legislative Assembly from Vikramgad (ST). The latest available result shows Harishchandra Bhoye winning the 2024 election from Vikramgad (ST) as a Bharatiya Janata Party candidate (WON). The latest record places Harishchandra Bhoye in Maharashtra with the Bharatiya Janata Party ticket for Vikramgad (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "54caf2e5-ef64-4880-8cf8-163132665f0d",
+    "name": "Rajendra Gavit",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Palghar (ST)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Palghar (ST)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajendra Gavit is a Maharashtra leader and Member of the Legislative Assembly from Palghar (ST). The latest available result shows Rajendra Gavit winning the 2024 election from Palghar (ST) as a Shiv Sena candidate (WON). The latest record places Rajendra Gavit in Maharashtra with the Shiv Sena ticket for Palghar (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "bb2a58b1-4f78-4c63-bdb6-81e03053ce96",
+    "name": "Vilas Tare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Boisar (ST)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Boisar (ST)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vilas Tare is a Maharashtra leader and Member of the Legislative Assembly from Boisar (ST). The latest available result shows Vilas Tare winning the 2024 election from Boisar (ST) as a Shiv Sena candidate (WON). The latest record places Vilas Tare in Maharashtra with the Shiv Sena ticket for Boisar (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "135537fc-97c6-4b75-97e5-a69784be7461",
+    "name": "Rajan Naik",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nalasopara",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nalasopara",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajan Naik is a Maharashtra leader and Member of the Legislative Assembly from Nalasopara. The latest available result shows Rajan Naik winning the 2024 election from Nalasopara as a Bharatiya Janata Party candidate (WON). The latest record places Rajan Naik in Maharashtra with the Bharatiya Janata Party ticket for Nalasopara.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "62195bb2-6b13-4c51-b3ad-c6f6d06dfbb7",
+    "name": "Sneha Pandit",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vasai",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vasai",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sneha Pandit is a Maharashtra leader and Member of the Legislative Assembly from Vasai. The latest available result shows Sneha Pandit winning the 2024 election from Vasai as a Bharatiya Janata Party candidate (WON). The latest record places Sneha Pandit in Maharashtra with the Bharatiya Janata Party ticket for Vasai.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d6bc350c-e666-4667-9b27-4bbb22e8d11e",
+    "name": "Shantaram More",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhiwandi Rural (ST)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhiwandi Rural (ST)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shantaram More is a Maharashtra leader and Member of the Legislative Assembly from Bhiwandi Rural (ST). The latest available result shows Shantaram More winning the 2024 election from Bhiwandi Rural (ST) as a Shiv Sena candidate (WON). The latest record places Shantaram More in Maharashtra with the Shiv Sena ticket for Bhiwandi Rural (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "f116f831-7262-4b37-b2cb-c7d8b7bb6c73",
+    "name": "Daulat Daroda",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shahapur (ST)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shahapur (ST)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Daulat Daroda is a Maharashtra leader and Member of the Legislative Assembly from Shahapur (ST). The latest available result shows Daulat Daroda winning the 2024 election from Shahapur (ST) as a Nationalist Congress Party candidate (WON). The latest record places Daulat Daroda in Maharashtra with the Nationalist Congress Party ticket for Shahapur (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6f28c067-2b2f-4037-bf5f-4835a659673e",
+    "name": "Mahesh Choughule",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhiwandi West",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhiwandi West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mahesh Choughule is a Maharashtra leader and Member of the Legislative Assembly from Bhiwandi West. The latest available result shows Mahesh Choughule winning the 2024 election from Bhiwandi West as a Bharatiya Janata Party candidate (WON). The latest record places Mahesh Choughule in Maharashtra with the Bharatiya Janata Party ticket for Bhiwandi West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2c90b6d5-79e9-46e9-a47c-f77cef21e0d9",
+    "name": "Rais Shaikh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhiwandi East",
+    "party": "Samajwadi Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhiwandi East",
+          "party": "Samajwadi Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rais Shaikh is a Maharashtra leader and Member of the Legislative Assembly from Bhiwandi East. The latest available result shows Rais Shaikh winning the 2024 election from Bhiwandi East as a Samajwadi Party candidate (WON). The latest record places Rais Shaikh in Maharashtra with the Samajwadi Party ticket for Bhiwandi East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1ca5a7bb-225d-42b2-90b5-e7d62709bb7e",
+    "name": "Vishwanath Bhoir",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kalyan West",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kalyan West",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vishwanath Bhoir is a Maharashtra leader and Member of the Legislative Assembly from Kalyan West. The latest available result shows Vishwanath Bhoir winning the 2024 election from Kalyan West as a Shiv Sena candidate (WON). The latest record places Vishwanath Bhoir in Maharashtra with the Shiv Sena ticket for Kalyan West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9f7d7ae8-7fc2-4050-a442-f3463f276dd7",
+    "name": "Kisan Kathore",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Murbad",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Murbad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kisan Kathore is a Maharashtra leader and Member of the Legislative Assembly from Murbad. The latest available result shows Kisan Kathore winning the 2024 election from Murbad as a Bharatiya Janata Party candidate (WON). The latest record places Kisan Kathore in Maharashtra with the Bharatiya Janata Party ticket for Murbad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "28c734d1-9d07-4012-a8eb-ca218d8084df",
+    "name": "Balaji Kinikar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ambernath (SC)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ambernath (SC)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Balaji Kinikar is a Maharashtra leader and Member of the Legislative Assembly from Ambernath (SC). The latest available result shows Balaji Kinikar winning the 2024 election from Ambernath (SC) as a Shiv Sena candidate (WON). The latest record places Balaji Kinikar in Maharashtra with the Shiv Sena ticket for Ambernath (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "eb76874e-3bd2-4d4b-a6d6-c11f3070379e",
+    "name": "Kumar Ailani",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ulhasnagar",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ulhasnagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kumar Ailani is a Maharashtra leader and Member of the Legislative Assembly from Ulhasnagar. The latest available result shows Kumar Ailani winning the 2024 election from Ulhasnagar as a Bharatiya Janata Party candidate (WON). The latest record places Kumar Ailani in Maharashtra with the Bharatiya Janata Party ticket for Ulhasnagar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "98621464-b88d-4690-a7aa-3ba3c27ba94d",
+    "name": "Sulbha Gaikwad",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kalyan East",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kalyan East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sulbha Gaikwad is a Maharashtra leader and Member of the Legislative Assembly from Kalyan East. The latest available result shows Sulbha Gaikwad winning the 2024 election from Kalyan East as a Bharatiya Janata Party candidate (WON). The latest record places Sulbha Gaikwad in Maharashtra with the Bharatiya Janata Party ticket for Kalyan East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5b67f35d-c31e-4c33-8ba8-f663e81f0fe1",
+    "name": "Ravindra Chavan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dombivali",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dombivali",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ravindra Chavan is a Maharashtra leader and Member of the Legislative Assembly from Dombivali. The latest available result shows Ravindra Chavan winning the 2024 election from Dombivali as a Bharatiya Janata Party candidate (WON). The latest record places Ravindra Chavan in Maharashtra with the Bharatiya Janata Party ticket for Dombivali.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4e096f2d-d53b-4505-bb0e-9dafb0c4af70",
+    "name": "Rajesh More",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kalyan Rural",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kalyan Rural",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajesh More is a Maharashtra leader and Member of the Legislative Assembly from Kalyan Rural. The latest available result shows Rajesh More winning the 2024 election from Kalyan Rural as a Shiv Sena candidate (WON). The latest record places Rajesh More in Maharashtra with the Shiv Sena ticket for Kalyan Rural.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "73c5c1cc-9a1c-441e-a2e7-ebaec66d7ef5",
+    "name": "Narendra Mehta",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mira Bhayandar",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mira Bhayandar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Narendra Mehta is a Maharashtra leader and Member of the Legislative Assembly from Mira Bhayandar. The latest available result shows Narendra Mehta winning the 2024 election from Mira Bhayandar as a Bharatiya Janata Party candidate (WON). The latest record places Narendra Mehta in Maharashtra with the Bharatiya Janata Party ticket for Mira Bhayandar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d67bc17b-bc58-4fdf-8cdf-fb9e400e012e",
+    "name": "Pratap Sarnaik",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ovala-Majiwada",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ovala-Majiwada",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Pratap Sarnaik is a Maharashtra leader and Member of the Legislative Assembly from Ovala-Majiwada. The latest available result shows Pratap Sarnaik winning the 2024 election from Ovala-Majiwada as a Shiv Sena candidate (WON). The latest record places Pratap Sarnaik in Maharashtra with the Shiv Sena ticket for Ovala-Majiwada.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2b05cf2e-3196-490d-bd24-d8a703bd6710",
+    "name": "Eknath Shinde",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kopri-Pachpakhadi",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kopri-Pachpakhadi",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Eknath Shinde is a Maharashtra leader and Member of the Legislative Assembly from Kopri-Pachpakhadi. The latest available result shows Eknath Shinde winning the 2024 election from Kopri-Pachpakhadi as a Shiv Sena candidate (WON). The latest record places Eknath Shinde in Maharashtra with the Shiv Sena ticket for Kopri-Pachpakhadi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9ddd8276-3477-4d89-8860-a56a528e7ec5",
+    "name": "Sanjay Kelkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Thane",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Thane",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Kelkar is a Maharashtra leader and Member of the Legislative Assembly from Thane. The latest available result shows Sanjay Kelkar winning the 2024 election from Thane as a Bharatiya Janata Party candidate (WON). The latest record places Sanjay Kelkar in Maharashtra with the Bharatiya Janata Party ticket for Thane.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "20d89fc7-a7ff-471a-9a6d-b707fa7bcd92",
+    "name": "Jitendra Awhad",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mumbra-Kalwa",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mumbra-Kalwa",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Jitendra Awhad is a Maharashtra leader and Member of the Legislative Assembly from Mumbra-Kalwa. The latest available result shows Jitendra Awhad winning the 2024 election from Mumbra-Kalwa as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Jitendra Awhad in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Mumbra-Kalwa.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "45884b67-effe-4599-95f4-1b5ffc37edb6",
+    "name": "Ganesh Naik",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Airoli",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Airoli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ganesh Naik is a Maharashtra leader and Member of the Legislative Assembly from Airoli. The latest available result shows Ganesh Naik winning the 2024 election from Airoli as a Bharatiya Janata Party candidate (WON). The latest record places Ganesh Naik in Maharashtra with the Bharatiya Janata Party ticket for Airoli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "3a587456-8fe6-4585-9065-fef748176c6a",
+    "name": "Manda Mhatre",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Belapur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Belapur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Manda Mhatre is a Maharashtra leader and Member of the Legislative Assembly from Belapur. The latest available result shows Manda Mhatre winning the 2024 election from Belapur as a Bharatiya Janata Party candidate (WON). The latest record places Manda Mhatre in Maharashtra with the Bharatiya Janata Party ticket for Belapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "cf3ba7a8-8387-4601-8307-ffbd211459bb",
+    "name": "Sanjay Upadhyay",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Borivali",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Borivali",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Upadhyay is a Maharashtra leader and Member of the Legislative Assembly from Borivali. The latest available result shows Sanjay Upadhyay winning the 2024 election from Borivali as a Bharatiya Janata Party candidate (WON). The latest record places Sanjay Upadhyay in Maharashtra with the Bharatiya Janata Party ticket for Borivali.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1fe1e53c-6c11-474f-98c6-df32aafb5514",
+    "name": "Manisha Chaudhary",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dahisar",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dahisar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Manisha Chaudhary is a Maharashtra leader and Member of the Legislative Assembly from Dahisar. The latest available result shows Manisha Chaudhary winning the 2024 election from Dahisar as a Bharatiya Janata Party candidate (WON). The latest record places Manisha Chaudhary in Maharashtra with the Bharatiya Janata Party ticket for Dahisar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "f0cf23a2-d650-4228-8adc-7b5931f5e1f5",
+    "name": "Prakash Surve",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Magathane",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Magathane",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Prakash Surve is a Maharashtra leader and Member of the Legislative Assembly from Magathane. The latest available result shows Prakash Surve winning the 2024 election from Magathane as a Shiv Sena candidate (WON). The latest record places Prakash Surve in Maharashtra with the Shiv Sena ticket for Magathane.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ce955fe6-30b2-4961-be09-14ceec61e627",
+    "name": "Mihir Kotecha",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mulund",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mulund",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mihir Kotecha is a Maharashtra leader and Member of the Legislative Assembly from Mulund. The latest available result shows Mihir Kotecha winning the 2024 election from Mulund as a Bharatiya Janata Party candidate (WON). The latest record places Mihir Kotecha in Maharashtra with the Bharatiya Janata Party ticket for Mulund.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "de02d107-a150-4fa7-9444-4b2b929038c2",
+    "name": "Sunil Raut",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vikhroli",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vikhroli",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sunil Raut is a Maharashtra leader and Member of the Legislative Assembly from Vikhroli. The latest available result shows Sunil Raut winning the 2024 election from Vikhroli as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Sunil Raut in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Vikhroli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "856285ba-2cba-489a-906a-920c78ce229e",
+    "name": "Ashok Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhandup West",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhandup West",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ashok Patil is a Maharashtra leader and Member of the Legislative Assembly from Bhandup West. The latest available result shows Ashok Patil winning the 2024 election from Bhandup West as a Shiv Sena candidate (WON). The latest record places Ashok Patil in Maharashtra with the Shiv Sena ticket for Bhandup West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "da7a3ccb-e9ef-492f-a793-7600621280ab",
+    "name": "Anant Nar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jogeshwari East",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jogeshwari East",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Anant Nar is a Maharashtra leader and Member of the Legislative Assembly from Jogeshwari East. The latest available result shows Anant Nar winning the 2024 election from Jogeshwari East as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Anant Nar in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Jogeshwari East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "3df9b386-c2bd-4b2f-870c-2e186b22a059",
+    "name": "Sunil Prabhu",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dindoshi",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dindoshi",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sunil Prabhu is a Maharashtra leader and Member of the Legislative Assembly from Dindoshi. The latest available result shows Sunil Prabhu winning the 2024 election from Dindoshi as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Sunil Prabhu in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Dindoshi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "952b7058-36b9-4f09-998f-41c29d4cebff",
+    "name": "Atul Bhatkhalkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kandivali East",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kandivali East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Atul Bhatkhalkar is a Maharashtra leader and Member of the Legislative Assembly from Kandivali East. The latest available result shows Atul Bhatkhalkar winning the 2024 election from Kandivali East as a Bharatiya Janata Party candidate (WON). The latest record places Atul Bhatkhalkar in Maharashtra with the Bharatiya Janata Party ticket for Kandivali East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "47003800-0aa8-4b98-a933-296c9fd62c32",
+    "name": "Yogesh Sagar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Charkop",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Charkop",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Yogesh Sagar is a Maharashtra leader and Member of the Legislative Assembly from Charkop. The latest available result shows Yogesh Sagar winning the 2024 election from Charkop as a Bharatiya Janata Party candidate (WON). The latest record places Yogesh Sagar in Maharashtra with the Bharatiya Janata Party ticket for Charkop.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "f90300f3-30ba-4035-b990-73e72d1a651f",
+    "name": "Aslam Shaikh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Malad West",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Malad West",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Aslam Shaikh is a Maharashtra leader and Member of the Legislative Assembly from Malad West. The latest available result shows Aslam Shaikh winning the 2024 election from Malad West as a Indian National Congress candidate (WON). The latest record places Aslam Shaikh in Maharashtra with the Indian National Congress ticket for Malad West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "caba438e-f6dc-4b89-843e-b241e9a21e4f",
+    "name": "Vidya Thakur",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Goregaon",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Goregaon",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vidya Thakur is a Maharashtra leader and Member of the Legislative Assembly from Goregaon. The latest available result shows Vidya Thakur winning the 2024 election from Goregaon as a Bharatiya Janata Party candidate (WON). The latest record places Vidya Thakur in Maharashtra with the Bharatiya Janata Party ticket for Goregaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "cc1ed6b9-1033-4531-bb88-91eb294c9ee3",
+    "name": "Haroon Rashid Khan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Versova",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Versova",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Haroon Rashid Khan is a Maharashtra leader and Member of the Legislative Assembly from Versova. The latest available result shows Haroon Rashid Khan winning the 2024 election from Versova as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Haroon Rashid Khan in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Versova.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "7bba8e30-9ab3-4f97-a561-d1c94504eda1",
+    "name": "Ameet Satam",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Andheri West",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Andheri West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ameet Satam is a Maharashtra leader and Member of the Legislative Assembly from Andheri West. The latest available result shows Ameet Satam winning the 2024 election from Andheri West as a Bharatiya Janata Party candidate (WON). The latest record places Ameet Satam in Maharashtra with the Bharatiya Janata Party ticket for Andheri West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "aee16ab7-8344-4b2a-b537-a1bbde663d11",
+    "name": "Murji Patel",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Andheri East",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Andheri East",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Murji Patel is a Maharashtra leader and Member of the Legislative Assembly from Andheri East. The latest available result shows Murji Patel winning the 2024 election from Andheri East as a Shiv Sena candidate (WON). The latest record places Murji Patel in Maharashtra with the Shiv Sena ticket for Andheri East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "343d3e86-5cb9-4b25-a314-810850183784",
+    "name": "Parag Alavani",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vile Parle",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vile Parle",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Parag Alavani is a Maharashtra leader and Member of the Legislative Assembly from Vile Parle. The latest available result shows Parag Alavani winning the 2024 election from Vile Parle as a Bharatiya Janata Party candidate (WON). The latest record places Parag Alavani in Maharashtra with the Bharatiya Janata Party ticket for Vile Parle.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d72c97fa-6ba5-48ba-8ab7-02c75b074535",
+    "name": "Dilip Lande",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chandivali",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chandivali",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dilip Lande is a Maharashtra leader and Member of the Legislative Assembly from Chandivali. The latest available result shows Dilip Lande winning the 2024 election from Chandivali as a Shiv Sena candidate (WON). The latest record places Dilip Lande in Maharashtra with the Shiv Sena ticket for Chandivali.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4fc2224b-cce8-41f1-86f2-fc3758a66cc6",
+    "name": "Ram Kadam",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ghatkopar West",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ghatkopar West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ram Kadam is a Maharashtra leader and Member of the Legislative Assembly from Ghatkopar West. The latest available result shows Ram Kadam winning the 2024 election from Ghatkopar West as a Bharatiya Janata Party candidate (WON). The latest record places Ram Kadam in Maharashtra with the Bharatiya Janata Party ticket for Ghatkopar West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c04a4e80-e478-43d5-bdee-59dd41cbbc85",
+    "name": "Parag Shah",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ghatkopar East",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ghatkopar East",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Parag Shah is a Maharashtra leader and Member of the Legislative Assembly from Ghatkopar East. The latest available result shows Parag Shah winning the 2024 election from Ghatkopar East as a Bharatiya Janata Party candidate (WON). The latest record places Parag Shah in Maharashtra with the Bharatiya Janata Party ticket for Ghatkopar East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "67a74348-8295-4aaf-9c27-4de2591c07b0",
+    "name": "Abu Azmi",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mankhurd Shivaji Nagar",
+    "party": "Samajwadi Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mankhurd Shivaji Nagar",
+          "party": "Samajwadi Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Abu Azmi is a Maharashtra leader and Member of the Legislative Assembly from Mankhurd Shivaji Nagar. The latest available result shows Abu Azmi winning the 2024 election from Mankhurd Shivaji Nagar as a Samajwadi Party candidate (WON). The latest record places Abu Azmi in Maharashtra with the Samajwadi Party ticket for Mankhurd Shivaji Nagar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "322f4ce8-9acb-4b92-bb1c-65ed698ef1bf",
+    "name": "Sana Malik",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Anushakti Nagar",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Anushakti Nagar",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sana Malik is a Maharashtra leader and Member of the Legislative Assembly from Anushakti Nagar. The latest available result shows Sana Malik winning the 2024 election from Anushakti Nagar as a Nationalist Congress Party candidate (WON). The latest record places Sana Malik in Maharashtra with the Nationalist Congress Party ticket for Anushakti Nagar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2e1b49be-1f3a-45b8-b214-cd84ceba68db",
+    "name": "Tukaram Kate",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chembur",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chembur",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Tukaram Kate is a Maharashtra leader and Member of the Legislative Assembly from Chembur. The latest available result shows Tukaram Kate winning the 2024 election from Chembur as a Shiv Sena candidate (WON). The latest record places Tukaram Kate in Maharashtra with the Shiv Sena ticket for Chembur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2af212f6-774f-4769-87dd-cef5f442c2a2",
+    "name": "Mangesh Kudalkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kurla (SC)",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kurla (SC)",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mangesh Kudalkar is a Maharashtra leader and Member of the Legislative Assembly from Kurla (SC). The latest available result shows Mangesh Kudalkar winning the 2024 election from Kurla (SC) as a Shiv Sena candidate (WON). The latest record places Mangesh Kudalkar in Maharashtra with the Shiv Sena ticket for Kurla (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4cfdb36d-afdc-4509-96a9-8c036c00bbaa",
+    "name": "Sanjay Potnis",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kalina",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kalina",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Potnis is a Maharashtra leader and Member of the Legislative Assembly from Kalina. The latest available result shows Sanjay Potnis winning the 2024 election from Kalina as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Sanjay Potnis in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Kalina.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c71f7feb-4e58-46a6-96d4-920d9eba84da",
+    "name": "Varun Sardesai",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vandre East",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vandre East",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Varun Sardesai is a Maharashtra leader and Member of the Legislative Assembly from Vandre East. The latest available result shows Varun Sardesai winning the 2024 election from Vandre East as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Varun Sardesai in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Vandre East.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "814b773b-ac04-465d-9198-5fbb929cc687",
+    "name": "Ashish Shelar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vandre West",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vandre West",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ashish Shelar is a Maharashtra leader and Member of the Legislative Assembly from Vandre West. The latest available result shows Ashish Shelar winning the 2024 election from Vandre West as a Bharatiya Janata Party candidate (WON). The latest record places Ashish Shelar in Maharashtra with the Bharatiya Janata Party ticket for Vandre West.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "f8fa58f3-e4f7-44ec-9768-45a7a433dfec",
+    "name": "Jyoti Gaikwad",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dharavi (SC)",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dharavi (SC)",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Jyoti Gaikwad is a Maharashtra leader and Member of the Legislative Assembly from Dharavi (SC). The latest available result shows Jyoti Gaikwad winning the 2024 election from Dharavi (SC) as a Indian National Congress candidate (WON). The latest record places Jyoti Gaikwad in Maharashtra with the Indian National Congress ticket for Dharavi (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "fa3ef296-3809-476b-a1c9-b77ea723e88c",
+    "name": "R. Tamil Selvan",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sion Koliwada",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sion Koliwada",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "R. Tamil Selvan is a Maharashtra leader and Member of the Legislative Assembly from Sion Koliwada. The latest available result shows R. Tamil Selvan winning the 2024 election from Sion Koliwada as a Bharatiya Janata Party candidate (WON). The latest record places R. Tamil Selvan in Maharashtra with the Bharatiya Janata Party ticket for Sion Koliwada.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1abe94e5-7603-41cc-ab80-b2caff4fd5a2",
+    "name": "Kalidas Kolambkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Wadala",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Wadala",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kalidas Kolambkar is a Maharashtra leader and Member of the Legislative Assembly from Wadala. The latest available result shows Kalidas Kolambkar winning the 2024 election from Wadala as a Bharatiya Janata Party candidate (WON). The latest record places Kalidas Kolambkar in Maharashtra with the Bharatiya Janata Party ticket for Wadala.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4a35b91a-592d-42e2-86d1-5b20cbd4939d",
+    "name": "Mahesh Sawant",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mahim",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mahim",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mahesh Sawant is a Maharashtra leader and Member of the Legislative Assembly from Mahim. The latest available result shows Mahesh Sawant winning the 2024 election from Mahim as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Mahesh Sawant in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Mahim.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b2a981a7-3754-4dca-a2cb-6b3e6d397266",
+    "name": "Aaditya Thackeray",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Worli",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Worli",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Aaditya Thackeray is a Maharashtra leader and Member of the Legislative Assembly from Worli. The latest available result shows Aaditya Thackeray winning the 2024 election from Worli as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Aaditya Thackeray in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Worli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0fd24f29-e2bc-47ca-89c1-a34992432de3",
+    "name": "Ajay Choudhari",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shivadi",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shivadi",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ajay Choudhari is a Maharashtra leader and Member of the Legislative Assembly from Shivadi. The latest available result shows Ajay Choudhari winning the 2024 election from Shivadi as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Ajay Choudhari in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Shivadi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4d8783c0-7dc6-417a-95a1-56ab1f8d15ea",
+    "name": "Manoj Jamsutkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Byculla",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Byculla",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Manoj Jamsutkar is a Maharashtra leader and Member of the Legislative Assembly from Byculla. The latest available result shows Manoj Jamsutkar winning the 2024 election from Byculla as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Manoj Jamsutkar in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Byculla.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d55af1c3-eecb-45cd-acbf-fc0546cd51d1",
+    "name": "Mangal Lodha",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Malabar Hill",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Malabar Hill",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mangal Lodha is a Maharashtra leader and Member of the Legislative Assembly from Malabar Hill. The latest available result shows Mangal Lodha winning the 2024 election from Malabar Hill as a Bharatiya Janata Party candidate (WON). The latest record places Mangal Lodha in Maharashtra with the Bharatiya Janata Party ticket for Malabar Hill.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a9e6c229-f20e-41a1-94ca-6ddfc2306072",
+    "name": "Amin Patel",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mumbadevi",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mumbadevi",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Amin Patel is a Maharashtra leader and Member of the Legislative Assembly from Mumbadevi. The latest available result shows Amin Patel winning the 2024 election from Mumbadevi as a Indian National Congress candidate (WON). The latest record places Amin Patel in Maharashtra with the Indian National Congress ticket for Mumbadevi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ea2cd7b1-1217-4db4-a2e0-9e231ddb8a4e",
+    "name": "Rahul Narwekar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Colaba",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Colaba",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rahul Narwekar is a Maharashtra leader and Member of the Legislative Assembly from Colaba. The latest available result shows Rahul Narwekar winning the 2024 election from Colaba as a Bharatiya Janata Party candidate (WON). The latest record places Rahul Narwekar in Maharashtra with the Bharatiya Janata Party ticket for Colaba.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "623fd6e9-6075-41d9-a347-32117e216693",
+    "name": "Prashant Thakur",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Panvel",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Panvel",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Prashant Thakur is a Maharashtra leader and Member of the Legislative Assembly from Panvel. The latest available result shows Prashant Thakur winning the 2024 election from Panvel as a Bharatiya Janata Party candidate (WON). The latest record places Prashant Thakur in Maharashtra with the Bharatiya Janata Party ticket for Panvel.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "128192e1-cba4-4f1b-bd1e-e8c658e7fe84",
+    "name": "Mahendra Thorve",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Karjat",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Karjat",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mahendra Thorve is a Maharashtra leader and Member of the Legislative Assembly from Karjat. The latest available result shows Mahendra Thorve winning the 2024 election from Karjat as a Shiv Sena candidate (WON). The latest record places Mahendra Thorve in Maharashtra with the Shiv Sena ticket for Karjat.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "06d6f2ea-a732-4960-81fb-ccc2af033b16",
+    "name": "Mahesh Baldi",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Uran",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Uran",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mahesh Baldi is a Maharashtra leader and Member of the Legislative Assembly from Uran. The latest available result shows Mahesh Baldi winning the 2024 election from Uran as a Bharatiya Janata Party candidate (WON). The latest record places Mahesh Baldi in Maharashtra with the Bharatiya Janata Party ticket for Uran.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b61bcf22-ed7d-4404-967b-875c538f355c",
+    "name": "Ravisheth Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Pen",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Pen",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ravisheth Patil is a Maharashtra leader and Member of the Legislative Assembly from Pen. The latest available result shows Ravisheth Patil winning the 2024 election from Pen as a Bharatiya Janata Party candidate (WON). The latest record places Ravisheth Patil in Maharashtra with the Bharatiya Janata Party ticket for Pen.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "cd37df95-f5c6-43cf-9a3b-c10ee901065b",
+    "name": "Mahendra Dalvi",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Alibag",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Alibag",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mahendra Dalvi is a Maharashtra leader and Member of the Legislative Assembly from Alibag. The latest available result shows Mahendra Dalvi winning the 2024 election from Alibag as a Shiv Sena candidate (WON). The latest record places Mahendra Dalvi in Maharashtra with the Shiv Sena ticket for Alibag.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2a37fae1-97e5-4d17-99a3-dc9bb7182e02",
+    "name": "Aditi Tatkare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shrivardhan",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shrivardhan",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Aditi Tatkare is a Maharashtra leader and Member of the Legislative Assembly from Shrivardhan. The latest available result shows Aditi Tatkare winning the 2024 election from Shrivardhan as a Nationalist Congress Party candidate (WON). The latest record places Aditi Tatkare in Maharashtra with the Nationalist Congress Party ticket for Shrivardhan.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1f1e5842-d13e-420c-8977-229410a3b7bf",
+    "name": "Bharatshet Gogawale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mahad",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mahad",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Bharatshet Gogawale is a Maharashtra leader and Member of the Legislative Assembly from Mahad. The latest available result shows Bharatshet Gogawale winning the 2024 election from Mahad as a Shiv Sena candidate (WON). The latest record places Bharatshet Gogawale in Maharashtra with the Shiv Sena ticket for Mahad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "67e0c9b3-8437-41a3-85d0-93b83966c169",
+    "name": "Sharaddada Sonavane",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Junnar",
+    "party": "Independent",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Junnar",
+          "party": "Independent",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sharaddada Sonavane is a Maharashtra leader and Member of the Legislative Assembly from Junnar. The latest available result shows Sharaddada Sonavane winning the 2024 election from Junnar as a Independent candidate (WON). The latest record places Sharaddada Sonavane in Maharashtra with the Independent ticket for Junnar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a613fc87-0d77-42ec-8401-cbd4abda0b5f",
+    "name": "Dilip Walse Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ambegaon",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ambegaon",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dilip Walse Patil is a Maharashtra leader and Member of the Legislative Assembly from Ambegaon. The latest available result shows Dilip Walse Patil winning the 2024 election from Ambegaon as a Nationalist Congress Party candidate (WON). The latest record places Dilip Walse Patil in Maharashtra with the Nationalist Congress Party ticket for Ambegaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "bfdb0878-cb06-42c1-a298-92224b01bb63",
+    "name": "Babaji Kale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Khed Alandi",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Khed Alandi",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Babaji Kale is a Maharashtra leader and Member of the Legislative Assembly from Khed Alandi. The latest available result shows Babaji Kale winning the 2024 election from Khed Alandi as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Babaji Kale in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Khed Alandi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d8cf8d02-6685-4a54-a80b-41933f50817a",
+    "name": "Dnyaneshwar Katke",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shirur",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shirur",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dnyaneshwar Katke is a Maharashtra leader and Member of the Legislative Assembly from Shirur. The latest available result shows Dnyaneshwar Katke winning the 2024 election from Shirur as a Nationalist Congress Party candidate (WON). The latest record places Dnyaneshwar Katke in Maharashtra with the Nationalist Congress Party ticket for Shirur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6e5e380e-c1c7-4a3f-a799-f93ce29b2d7d",
+    "name": "Rahul Kul",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Daund",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Daund",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rahul Kul is a Maharashtra leader and Member of the Legislative Assembly from Daund. The latest available result shows Rahul Kul winning the 2024 election from Daund as a Bharatiya Janata Party candidate (WON). The latest record places Rahul Kul in Maharashtra with the Bharatiya Janata Party ticket for Daund.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6cb96dfb-d65b-4cc9-acdc-1bd638e46d0d",
+    "name": "Dattatray Bharne",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Indapur",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Indapur",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dattatray Bharne is a Maharashtra leader and Member of the Legislative Assembly from Indapur. The latest available result shows Dattatray Bharne winning the 2024 election from Indapur as a Nationalist Congress Party candidate (WON). The latest record places Dattatray Bharne in Maharashtra with the Nationalist Congress Party ticket for Indapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "41d59795-8133-4a17-95b0-e8f13af8f7e9",
+    "name": "Ajit Pawar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Baramati",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Baramati",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ajit Pawar is a Maharashtra leader and Member of the Legislative Assembly from Baramati. The latest available result shows Ajit Pawar winning the 2024 election from Baramati as a Nationalist Congress Party candidate (WON). The latest record places Ajit Pawar in Maharashtra with the Nationalist Congress Party ticket for Baramati.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "44a9ff27-1b01-4d7b-b38c-e0c4cb94b96d",
+    "name": "Vijay Shivtare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Purandar",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Purandar",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vijay Shivtare is a Maharashtra leader and Member of the Legislative Assembly from Purandar. The latest available result shows Vijay Shivtare winning the 2024 election from Purandar as a Shiv Sena candidate (WON). The latest record places Vijay Shivtare in Maharashtra with the Shiv Sena ticket for Purandar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0f2b8275-5581-4b90-b4a4-0799d90d52e0",
+    "name": "Shankar Mandekar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhor",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhor",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shankar Mandekar is a Maharashtra leader and Member of the Legislative Assembly from Bhor. The latest available result shows Shankar Mandekar winning the 2024 election from Bhor as a Nationalist Congress Party candidate (WON). The latest record places Shankar Mandekar in Maharashtra with the Nationalist Congress Party ticket for Bhor.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "049baede-ffe7-4f76-afba-28142e370e92",
+    "name": "Sunil Shelke",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Maval",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Maval",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sunil Shelke is a Maharashtra leader and Member of the Legislative Assembly from Maval. The latest available result shows Sunil Shelke winning the 2024 election from Maval as a Nationalist Congress Party candidate (WON). The latest record places Sunil Shelke in Maharashtra with the Nationalist Congress Party ticket for Maval.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d3ac3689-3d2f-4b42-8451-ab3c9f1e59a4",
+    "name": "Shankar Jagtap",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chinchwad",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chinchwad",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shankar Jagtap is a Maharashtra leader and Member of the Legislative Assembly from Chinchwad. The latest available result shows Shankar Jagtap winning the 2024 election from Chinchwad as a Bharatiya Janata Party candidate (WON). The latest record places Shankar Jagtap in Maharashtra with the Bharatiya Janata Party ticket for Chinchwad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "bc40f6b4-a019-42db-82ec-7ac0753829b4",
+    "name": "Anna Bansode",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Pimpri (SC)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Pimpri (SC)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Anna Bansode is a Maharashtra leader and Member of the Legislative Assembly from Pimpri (SC). The latest available result shows Anna Bansode winning the 2024 election from Pimpri (SC) as a Nationalist Congress Party candidate (WON). The latest record places Anna Bansode in Maharashtra with the Nationalist Congress Party ticket for Pimpri (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2d045f17-da61-4386-9b2a-98fb849678b4",
+    "name": "Mahesh Landge",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Bhosari",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Bhosari",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mahesh Landge is a Maharashtra leader and Member of the Legislative Assembly from Bhosari. The latest available result shows Mahesh Landge winning the 2024 election from Bhosari as a Bharatiya Janata Party candidate (WON). The latest record places Mahesh Landge in Maharashtra with the Bharatiya Janata Party ticket for Bhosari.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "907a4827-3224-4efa-9ba0-4fd4f76c0ba6",
+    "name": "Bapusaheb Pathare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Vadgaon Sheri",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Vadgaon Sheri",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Bapusaheb Pathare is a Maharashtra leader and Member of the Legislative Assembly from Vadgaon Sheri. The latest available result shows Bapusaheb Pathare winning the 2024 election from Vadgaon Sheri as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Bapusaheb Pathare in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Vadgaon Sheri.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2ae31b6c-6fe4-4251-bef7-52d68ac77280",
+    "name": "Siddharth Shirole",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shivajinagar",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shivajinagar",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Siddharth Shirole is a Maharashtra leader and Member of the Legislative Assembly from Shivajinagar. The latest available result shows Siddharth Shirole winning the 2024 election from Shivajinagar as a Bharatiya Janata Party candidate (WON). The latest record places Siddharth Shirole in Maharashtra with the Bharatiya Janata Party ticket for Shivajinagar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8ff29fab-1f68-43d2-9046-708982c397af",
+    "name": "Chandrakant Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kothrud",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kothrud",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chandrakant Patil is a Maharashtra leader and Member of the Legislative Assembly from Kothrud. The latest available result shows Chandrakant Patil winning the 2024 election from Kothrud as a Bharatiya Janata Party candidate (WON). The latest record places Chandrakant Patil in Maharashtra with the Bharatiya Janata Party ticket for Kothrud.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "fbf58106-a666-4f64-94d5-b0abfaac0390",
+    "name": "Bhimrao Tapkir",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Khadakwasala",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Khadakwasala",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Bhimrao Tapkir is a Maharashtra leader and Member of the Legislative Assembly from Khadakwasala. The latest available result shows Bhimrao Tapkir winning the 2024 election from Khadakwasala as a Bharatiya Janata Party candidate (WON). The latest record places Bhimrao Tapkir in Maharashtra with the Bharatiya Janata Party ticket for Khadakwasala.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "f83655e1-d9fe-44ad-9240-5d7445934d33",
+    "name": "Madhuri Misal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Parvati",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Parvati",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Madhuri Misal is a Maharashtra leader and Member of the Legislative Assembly from Parvati. The latest available result shows Madhuri Misal winning the 2024 election from Parvati as a Bharatiya Janata Party candidate (WON). The latest record places Madhuri Misal in Maharashtra with the Bharatiya Janata Party ticket for Parvati.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1bd16c60-bd15-4d84-ad2b-329abc8886b4",
+    "name": "Chetan Tupe",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Hadapsar",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Hadapsar",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chetan Tupe is a Maharashtra leader and Member of the Legislative Assembly from Hadapsar. The latest available result shows Chetan Tupe winning the 2024 election from Hadapsar as a Nationalist Congress Party candidate (WON). The latest record places Chetan Tupe in Maharashtra with the Nationalist Congress Party ticket for Hadapsar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5f50fb02-a3f2-43a1-8d7e-9e5f2071cc02",
+    "name": "Sunil Kamble",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Pune Cantonment (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Pune Cantonment (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sunil Kamble is a Maharashtra leader and Member of the Legislative Assembly from Pune Cantonment (SC). The latest available result shows Sunil Kamble winning the 2024 election from Pune Cantonment (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Sunil Kamble in Maharashtra with the Bharatiya Janata Party ticket for Pune Cantonment (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8722e24d-f2d5-465c-9742-9964e2d7c933",
+    "name": "Hemant Rasane",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kasba Peth",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kasba Peth",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Hemant Rasane is a Maharashtra leader and Member of the Legislative Assembly from Kasba Peth. The latest available result shows Hemant Rasane winning the 2024 election from Kasba Peth as a Bharatiya Janata Party candidate (WON). The latest record places Hemant Rasane in Maharashtra with the Bharatiya Janata Party ticket for Kasba Peth.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "35f16a8b-4402-41a8-a49e-94b6bb89b601",
+    "name": "Kiran Lahamate",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Akole (ST)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Akole (ST)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kiran Lahamate is a Maharashtra leader and Member of the Legislative Assembly from Akole (ST). The latest available result shows Kiran Lahamate winning the 2024 election from Akole (ST) as a Nationalist Congress Party candidate (WON). The latest record places Kiran Lahamate in Maharashtra with the Nationalist Congress Party ticket for Akole (ST).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "e052f394-92c5-4365-827f-4c4dc2e779eb",
+    "name": "Amol Khatal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sangamner",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sangamner",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Amol Khatal is a Maharashtra leader and Member of the Legislative Assembly from Sangamner. The latest available result shows Amol Khatal winning the 2024 election from Sangamner as a Shiv Sena candidate (WON). The latest record places Amol Khatal in Maharashtra with the Shiv Sena ticket for Sangamner.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "7b5a0bad-5b99-4d6f-b96c-35ade7f9db63",
+    "name": "Radhakrishna Vikhe Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shirdi",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shirdi",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Radhakrishna Vikhe Patil is a Maharashtra leader and Member of the Legislative Assembly from Shirdi. The latest available result shows Radhakrishna Vikhe Patil winning the 2024 election from Shirdi as a Bharatiya Janata Party candidate (WON). The latest record places Radhakrishna Vikhe Patil in Maharashtra with the Bharatiya Janata Party ticket for Shirdi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "15963f37-3a2c-495e-b607-5ae9ea539a4e",
+    "name": "Ashutosh Kale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kopargaon",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kopargaon",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ashutosh Kale is a Maharashtra leader and Member of the Legislative Assembly from Kopargaon. The latest available result shows Ashutosh Kale winning the 2024 election from Kopargaon as a Nationalist Congress Party candidate (WON). The latest record places Ashutosh Kale in Maharashtra with the Nationalist Congress Party ticket for Kopargaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6d23ee46-df1a-467a-b2d8-287714667717",
+    "name": "Hemant Ogale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shrirampur (SC)",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shrirampur (SC)",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Hemant Ogale is a Maharashtra leader and Member of the Legislative Assembly from Shrirampur (SC). The latest available result shows Hemant Ogale winning the 2024 election from Shrirampur (SC) as a Indian National Congress candidate (WON). The latest record places Hemant Ogale in Maharashtra with the Indian National Congress ticket for Shrirampur (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "83839dd8-1d6b-4b9a-85ee-a0dc1d547e8a",
+    "name": "Vitthal Langhe",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nevasa",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nevasa",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vitthal Langhe is a Maharashtra leader and Member of the Legislative Assembly from Nevasa. The latest available result shows Vitthal Langhe winning the 2024 election from Nevasa as a Shiv Sena candidate (WON). The latest record places Vitthal Langhe in Maharashtra with the Shiv Sena ticket for Nevasa.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6492fafc-9cfd-4e55-be0a-d416e216b569",
+    "name": "Monika Rajale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shevgaon",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shevgaon",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Monika Rajale is a Maharashtra leader and Member of the Legislative Assembly from Shevgaon. The latest available result shows Monika Rajale winning the 2024 election from Shevgaon as a Bharatiya Janata Party candidate (WON). The latest record places Monika Rajale in Maharashtra with the Bharatiya Janata Party ticket for Shevgaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "54839096-8a38-4835-beb9-812d8acff76d",
+    "name": "Shivaji Kardile",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Rahuri",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Rahuri",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shivaji Kardile is a Maharashtra leader and Member of the Legislative Assembly from Rahuri. The latest available result shows Shivaji Kardile winning the 2024 election from Rahuri as a Bharatiya Janata Party candidate (WON). The latest record places Shivaji Kardile in Maharashtra with the Bharatiya Janata Party ticket for Rahuri.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9751c596-9acd-424e-8834-52048a3f1031",
+    "name": "Kashinath Date",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Parner",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Parner",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kashinath Date is a Maharashtra leader and Member of the Legislative Assembly from Parner. The latest available result shows Kashinath Date winning the 2024 election from Parner as a Nationalist Congress Party candidate (WON). The latest record places Kashinath Date in Maharashtra with the Nationalist Congress Party ticket for Parner.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "14c58236-96c6-48cf-9e34-3f5e748198ed",
+    "name": "Sangram  Jagtap",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ahmednagar City",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ahmednagar City",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sangram  Jagtap is a Maharashtra leader and Member of the Legislative Assembly from Ahmednagar City. The latest available result shows Sangram  Jagtap winning the 2024 election from Ahmednagar City as a Nationalist Congress Party candidate (WON). The latest record places Sangram  Jagtap in Maharashtra with the Nationalist Congress Party ticket for Ahmednagar City.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "891abfb7-2e6c-48b2-b9c5-3a7f40ac1664",
+    "name": "Vikram Pachpute",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shrigonda",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shrigonda",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vikram Pachpute is a Maharashtra leader and Member of the Legislative Assembly from Shrigonda. The latest available result shows Vikram Pachpute winning the 2024 election from Shrigonda as a Bharatiya Janata Party candidate (WON). The latest record places Vikram Pachpute in Maharashtra with the Bharatiya Janata Party ticket for Shrigonda.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0255da96-6bc9-4eb1-a8a5-4c0881c844fc",
+    "name": "Rohit Pawar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Karjat Jamkhed",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Karjat Jamkhed",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rohit Pawar is a Maharashtra leader and Member of the Legislative Assembly from Karjat Jamkhed. The latest available result shows Rohit Pawar winning the 2024 election from Karjat Jamkhed as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Rohit Pawar in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Karjat Jamkhed.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "ceffe9f7-7aa3-4f43-af1c-4f5d59a3981f",
+    "name": "Vijaysinh Pandit",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Georai",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Georai",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vijaysinh Pandit is a Maharashtra leader and Member of the Legislative Assembly from Georai. The latest available result shows Vijaysinh Pandit winning the 2024 election from Georai as a Nationalist Congress Party candidate (WON). The latest record places Vijaysinh Pandit in Maharashtra with the Nationalist Congress Party ticket for Georai.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c3946ec1-8eb3-41bb-8194-b36f426cb6e7",
+    "name": "Prakashdada Solanke",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Majalgaon",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Majalgaon",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Prakashdada Solanke is a Maharashtra leader and Member of the Legislative Assembly from Majalgaon. The latest available result shows Prakashdada Solanke winning the 2024 election from Majalgaon as a Nationalist Congress Party candidate (WON). The latest record places Prakashdada Solanke in Maharashtra with the Nationalist Congress Party ticket for Majalgaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "46b127bb-6278-45bf-9ade-fd6373625568",
+    "name": "Sandeep Kshirsagar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Beed",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Beed",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sandeep Kshirsagar is a Maharashtra leader and Member of the Legislative Assembly from Beed. The latest available result shows Sandeep Kshirsagar winning the 2024 election from Beed as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Sandeep Kshirsagar in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Beed.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c912e66f-ba74-425d-b288-ac1347f8642d",
+    "name": "Suresh Dhas",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ashti",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ashti",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Suresh Dhas is a Maharashtra leader and Member of the Legislative Assembly from Ashti. The latest available result shows Suresh Dhas winning the 2024 election from Ashti as a Bharatiya Janata Party candidate (WON). The latest record places Suresh Dhas in Maharashtra with the Bharatiya Janata Party ticket for Ashti.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d17c1458-4cff-4733-a08a-788ca5e4cb68",
+    "name": "Namita Mundada",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kaij (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kaij (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Namita Mundada is a Maharashtra leader and Member of the Legislative Assembly from Kaij (SC). The latest available result shows Namita Mundada winning the 2024 election from Kaij (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Namita Mundada in Maharashtra with the Bharatiya Janata Party ticket for Kaij (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "88d87ec0-3857-44f3-a0c9-83fa92981046",
+    "name": "Dhananjay Munde",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Parli",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Parli",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dhananjay Munde is a Maharashtra leader and Member of the Legislative Assembly from Parli. The latest available result shows Dhananjay Munde winning the 2024 election from Parli as a Nationalist Congress Party candidate (WON). The latest record places Dhananjay Munde in Maharashtra with the Nationalist Congress Party ticket for Parli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d62a3983-5830-418b-8545-9eae67165c90",
+    "name": "Ramesh Karad",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Latur Rural",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Latur Rural",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ramesh Karad is a Maharashtra leader and Member of the Legislative Assembly from Latur Rural. The latest available result shows Ramesh Karad winning the 2024 election from Latur Rural as a Bharatiya Janata Party candidate (WON). The latest record places Ramesh Karad in Maharashtra with the Bharatiya Janata Party ticket for Latur Rural.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6a1977ed-8897-4ff2-9099-b923cf70981e",
+    "name": "Amit Deshmukh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Latur City",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Latur City",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Amit Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Latur City. The latest available result shows Amit Deshmukh winning the 2024 election from Latur City as a Indian National Congress candidate (WON). The latest record places Amit Deshmukh in Maharashtra with the Indian National Congress ticket for Latur City.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "0b1f7936-fa1c-470e-9f00-5ab6bc10fcef",
+    "name": "Babasaheb M. Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ahmedpur",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ahmedpur",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Babasaheb M. Patil is a Maharashtra leader and Member of the Legislative Assembly from Ahmedpur. The latest available result shows Babasaheb M. Patil winning the 2024 election from Ahmedpur as a Nationalist Congress Party candidate (WON). The latest record places Babasaheb M. Patil in Maharashtra with the Nationalist Congress Party ticket for Ahmedpur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "3a775b72-362e-43ed-bdeb-eb0d007a29d5",
+    "name": "Sanjay Bansode",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Udgir (SC)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Udgir (SC)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sanjay Bansode is a Maharashtra leader and Member of the Legislative Assembly from Udgir (SC). The latest available result shows Sanjay Bansode winning the 2024 election from Udgir (SC) as a Nationalist Congress Party candidate (WON). The latest record places Sanjay Bansode in Maharashtra with the Nationalist Congress Party ticket for Udgir (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8c550aa2-322e-4fd8-9a97-4093526a62aa",
+    "name": "Sambhaji Patil Nilangekar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Nilanga",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Nilanga",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sambhaji Patil Nilangekar is a Maharashtra leader and Member of the Legislative Assembly from Nilanga. The latest available result shows Sambhaji Patil Nilangekar winning the 2024 election from Nilanga as a Bharatiya Janata Party candidate (WON). The latest record places Sambhaji Patil Nilangekar in Maharashtra with the Bharatiya Janata Party ticket for Nilanga.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a225142c-4961-4855-811e-c2b462b1a4a5",
+    "name": "Abhimanyu Pawar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ausa",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ausa",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Abhimanyu Pawar is a Maharashtra leader and Member of the Legislative Assembly from Ausa. The latest available result shows Abhimanyu Pawar winning the 2024 election from Ausa as a Bharatiya Janata Party candidate (WON). The latest record places Abhimanyu Pawar in Maharashtra with the Bharatiya Janata Party ticket for Ausa.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4c27f11f-449b-4e8e-8014-a93594a7d58b",
+    "name": "Pravin Swami",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Umarga (SC)",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Umarga (SC)",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Pravin Swami is a Maharashtra leader and Member of the Legislative Assembly from Umarga (SC). The latest available result shows Pravin Swami winning the 2024 election from Umarga (SC) as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Pravin Swami in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Umarga (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a12f1a91-f9bd-4125-89f4-88c9f7cfcc0a",
+    "name": "Ranajagjitsinha Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Tuljapur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Tuljapur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ranajagjitsinha Patil is a Maharashtra leader and Member of the Legislative Assembly from Tuljapur. The latest available result shows Ranajagjitsinha Patil winning the 2024 election from Tuljapur as a Bharatiya Janata Party candidate (WON). The latest record places Ranajagjitsinha Patil in Maharashtra with the Bharatiya Janata Party ticket for Tuljapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "3bf6fb84-85cb-4011-9362-cd397a1b9f36",
+    "name": "Kailas Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Osmanabad",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Osmanabad",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kailas Patil is a Maharashtra leader and Member of the Legislative Assembly from Osmanabad. The latest available result shows Kailas Patil winning the 2024 election from Osmanabad as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Kailas Patil in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Osmanabad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "bba65ae4-64e1-4c8b-bbaa-f06b48947e77",
+    "name": "Tanaji Sawant",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Paranda",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Paranda",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Tanaji Sawant is a Maharashtra leader and Member of the Legislative Assembly from Paranda. The latest available result shows Tanaji Sawant winning the 2024 election from Paranda as a Shiv Sena candidate (WON). The latest record places Tanaji Sawant in Maharashtra with the Shiv Sena ticket for Paranda.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a1196e83-31ee-47c8-af88-8a1a369549f2",
+    "name": "Narayan Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Karmala",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Karmala",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Narayan Patil is a Maharashtra leader and Member of the Legislative Assembly from Karmala. The latest available result shows Narayan Patil winning the 2024 election from Karmala as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Narayan Patil in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Karmala.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8c68767a-b394-4389-996a-566b7947a843",
+    "name": "Abhijeet Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Madha",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Madha",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Abhijeet Patil is a Maharashtra leader and Member of the Legislative Assembly from Madha. The latest available result shows Abhijeet Patil winning the 2024 election from Madha as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Abhijeet Patil in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Madha.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "828af7e6-5a3c-4776-92e7-7671e54396dd",
+    "name": "Dilip Sopal",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Barshi",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Barshi",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Dilip Sopal is a Maharashtra leader and Member of the Legislative Assembly from Barshi. The latest available result shows Dilip Sopal winning the 2024 election from Barshi as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Dilip Sopal in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Barshi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "39eff430-4f5e-4b89-99e9-5a8d45066437",
+    "name": "Raju Khare",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Mohol (SC)",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Mohol (SC)",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Raju Khare is a Maharashtra leader and Member of the Legislative Assembly from Mohol (SC). The latest available result shows Raju Khare winning the 2024 election from Mohol (SC) as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Raju Khare in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Mohol (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5029ac4d-25de-4d38-a0ff-3cc12e893d8e",
+    "name": "Vijay Deshmukh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Solapur City North",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Solapur City North",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vijay Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Solapur City North. The latest available result shows Vijay Deshmukh winning the 2024 election from Solapur City North as a Bharatiya Janata Party candidate (WON). The latest record places Vijay Deshmukh in Maharashtra with the Bharatiya Janata Party ticket for Solapur City North.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a8036b0b-8d2d-4d1b-a032-de78d689061e",
+    "name": "Devendra Kothe",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Solapur City Central",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Solapur City Central",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Devendra Kothe is a Maharashtra leader and Member of the Legislative Assembly from Solapur City Central. The latest available result shows Devendra Kothe winning the 2024 election from Solapur City Central as a Bharatiya Janata Party candidate (WON). The latest record places Devendra Kothe in Maharashtra with the Bharatiya Janata Party ticket for Solapur City Central.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9017d7c0-963c-4379-abfa-645d44bb1e10",
+    "name": "Sachin Kalyanshetti",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Akkalkot",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Akkalkot",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sachin Kalyanshetti is a Maharashtra leader and Member of the Legislative Assembly from Akkalkot. The latest available result shows Sachin Kalyanshetti winning the 2024 election from Akkalkot as a Bharatiya Janata Party candidate (WON). The latest record places Sachin Kalyanshetti in Maharashtra with the Bharatiya Janata Party ticket for Akkalkot.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "1c6a82e4-b5e7-4cfd-838b-3eb6b206a0aa",
+    "name": "Subhash Deshmukh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Solapur South",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Solapur South",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Subhash Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Solapur South. The latest available result shows Subhash Deshmukh winning the 2024 election from Solapur South as a Bharatiya Janata Party candidate (WON). The latest record places Subhash Deshmukh in Maharashtra with the Bharatiya Janata Party ticket for Solapur South.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "4d64c087-f94c-41ae-b850-6515f84cd0dd",
+    "name": "Samadhan Autade",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Pandharpur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Pandharpur",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Samadhan Autade is a Maharashtra leader and Member of the Legislative Assembly from Pandharpur. The latest available result shows Samadhan Autade winning the 2024 election from Pandharpur as a Bharatiya Janata Party candidate (WON). The latest record places Samadhan Autade in Maharashtra with the Bharatiya Janata Party ticket for Pandharpur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9df0cea0-2c68-4665-8428-37c4f9381234",
+    "name": "Babasaheb Deshmukh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sangola",
+    "party": "Peasants and Workers Party of India",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sangola",
+          "party": "Peasants and Workers Party of India",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Babasaheb Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Sangola. The latest available result shows Babasaheb Deshmukh winning the 2024 election from Sangola as a Peasants and Workers Party of India candidate (WON). The latest record places Babasaheb Deshmukh in Maharashtra with the Peasants and Workers Party of India ticket for Sangola.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "2d366f65-cd51-4e27-822b-4194947e56fd",
+    "name": "Uttamrao Jankar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Malshiras (SC)",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Malshiras (SC)",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Uttamrao Jankar is a Maharashtra leader and Member of the Legislative Assembly from Malshiras (SC). The latest available result shows Uttamrao Jankar winning the 2024 election from Malshiras (SC) as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Uttamrao Jankar in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Malshiras (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "83977bea-9166-46b9-ae03-0680c77bb56a",
+    "name": "Sachin Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Phaltan (SC)",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Phaltan (SC)",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sachin Patil is a Maharashtra leader and Member of the Legislative Assembly from Phaltan (SC). The latest available result shows Sachin Patil winning the 2024 election from Phaltan (SC) as a Nationalist Congress Party candidate (WON). The latest record places Sachin Patil in Maharashtra with the Nationalist Congress Party ticket for Phaltan (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "6bbb0c59-db61-48fc-b905-7a584735a5d0",
+    "name": "Makrand Jadhav - Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Wai",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Wai",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Makrand Jadhav - Patil is a Maharashtra leader and Member of the Legislative Assembly from Wai. The latest available result shows Makrand Jadhav - Patil winning the 2024 election from Wai as a Nationalist Congress Party candidate (WON). The latest record places Makrand Jadhav - Patil in Maharashtra with the Nationalist Congress Party ticket for Wai.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5e42e08c-a48c-4d72-84eb-0cc7118f888c",
+    "name": "Mahesh Shinde",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Koregaon",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Koregaon",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Mahesh Shinde is a Maharashtra leader and Member of the Legislative Assembly from Koregaon. The latest available result shows Mahesh Shinde winning the 2024 election from Koregaon as a Shiv Sena candidate (WON). The latest record places Mahesh Shinde in Maharashtra with the Shiv Sena ticket for Koregaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b21aa22e-831b-4027-89c6-e6f8112aff00",
+    "name": "Jaykumar Gore",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Man",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Man",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Jaykumar Gore is a Maharashtra leader and Member of the Legislative Assembly from Man. The latest available result shows Jaykumar Gore winning the 2024 election from Man as a Bharatiya Janata Party candidate (WON). The latest record places Jaykumar Gore in Maharashtra with the Bharatiya Janata Party ticket for Man.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "f030f236-4c3f-4d17-9b63-f787ac44a037",
+    "name": "Manoj Ghorpade",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Karad North",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Karad North",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Manoj Ghorpade is a Maharashtra leader and Member of the Legislative Assembly from Karad North. The latest available result shows Manoj Ghorpade winning the 2024 election from Karad North as a Bharatiya Janata Party candidate (WON). The latest record places Manoj Ghorpade in Maharashtra with the Bharatiya Janata Party ticket for Karad North.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "18493568-81f0-44b7-8012-530ae2572451",
+    "name": "Atulbaba Bhosale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Karad South",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Karad South",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Atulbaba Bhosale is a Maharashtra leader and Member of the Legislative Assembly from Karad South. The latest available result shows Atulbaba Bhosale winning the 2024 election from Karad South as a Bharatiya Janata Party candidate (WON). The latest record places Atulbaba Bhosale in Maharashtra with the Bharatiya Janata Party ticket for Karad South.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "802a2c0d-e0a7-4e12-b3c1-a5e7555c7559",
+    "name": "Shambhuraj Desai",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Patan",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Patan",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shambhuraj Desai is a Maharashtra leader and Member of the Legislative Assembly from Patan. The latest available result shows Shambhuraj Desai winning the 2024 election from Patan as a Shiv Sena candidate (WON). The latest record places Shambhuraj Desai in Maharashtra with the Shiv Sena ticket for Patan.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "7146d3e2-8f5a-44d5-afad-2191aa013a69",
+    "name": "Shivendra Raje Bhosale",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Satara",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Satara",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shivendra Raje Bhosale is a Maharashtra leader and Member of the Legislative Assembly from Satara. The latest available result shows Shivendra Raje Bhosale winning the 2024 election from Satara as a Bharatiya Janata Party candidate (WON). The latest record places Shivendra Raje Bhosale in Maharashtra with the Bharatiya Janata Party ticket for Satara.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "06e9a2d7-75de-4245-a71b-9c9140e6bc4f",
+    "name": "Yogesh Kadam",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Dapoli",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Dapoli",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Yogesh Kadam is a Maharashtra leader and Member of the Legislative Assembly from Dapoli. The latest available result shows Yogesh Kadam winning the 2024 election from Dapoli as a Shiv Sena candidate (WON). The latest record places Yogesh Kadam in Maharashtra with the Shiv Sena ticket for Dapoli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b64a8d7b-16b3-43f3-919f-c6ca39c62dae",
+    "name": "Bhaskar Jadhav",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Guhagar",
+    "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Guhagar",
+          "party": "Shiv Sena (Uddhav Balasaheb Thackeray)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Bhaskar Jadhav is a Maharashtra leader and Member of the Legislative Assembly from Guhagar. The latest available result shows Bhaskar Jadhav winning the 2024 election from Guhagar as a Shiv Sena (Uddhav Balasaheb Thackeray) candidate (WON). The latest record places Bhaskar Jadhav in Maharashtra with the Shiv Sena (Uddhav Balasaheb Thackeray) ticket for Guhagar.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9469453b-cb55-4b79-a077-f62083e74ae1",
+    "name": "Shekhar Nikam",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chiplun",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chiplun",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shekhar Nikam is a Maharashtra leader and Member of the Legislative Assembly from Chiplun. The latest available result shows Shekhar Nikam winning the 2024 election from Chiplun as a Nationalist Congress Party candidate (WON). The latest record places Shekhar Nikam in Maharashtra with the Nationalist Congress Party ticket for Chiplun.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "5488192d-96a2-44e2-a133-ad78a3b3c246",
+    "name": "Uday Samant",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ratnagiri",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ratnagiri",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Uday Samant is a Maharashtra leader and Member of the Legislative Assembly from Ratnagiri. The latest available result shows Uday Samant winning the 2024 election from Ratnagiri as a Shiv Sena candidate (WON). The latest record places Uday Samant in Maharashtra with the Shiv Sena ticket for Ratnagiri.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9f7aad34-170c-4822-bc78-842a413bae5f",
+    "name": "Kiran Samant",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Rajapur",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Rajapur",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Kiran Samant is a Maharashtra leader and Member of the Legislative Assembly from Rajapur. The latest available result shows Kiran Samant winning the 2024 election from Rajapur as a Shiv Sena candidate (WON). The latest record places Kiran Samant in Maharashtra with the Shiv Sena ticket for Rajapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b5603cfa-17ba-446d-b7c2-f8a9f9850782",
+    "name": "Nitesh Rane",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kankavli",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kankavli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Nitesh Rane is a Maharashtra leader and Member of the Legislative Assembly from Kankavli. The latest available result shows Nitesh Rane winning the 2024 election from Kankavli as a Bharatiya Janata Party candidate (WON). The latest record places Nitesh Rane in Maharashtra with the Bharatiya Janata Party ticket for Kankavli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "45ff2158-f9eb-4995-b544-11b0ead4c155",
+    "name": "Nilesh Rane",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kudal",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kudal",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Nilesh Rane is a Maharashtra leader and Member of the Legislative Assembly from Kudal. The latest available result shows Nilesh Rane winning the 2024 election from Kudal as a Shiv Sena candidate (WON). The latest record places Nilesh Rane in Maharashtra with the Shiv Sena ticket for Kudal.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8b75c704-4c8d-42e1-9a3d-8be44a0965c7",
+    "name": "Deepak Kesarkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sawantwadi",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sawantwadi",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Deepak Kesarkar is a Maharashtra leader and Member of the Legislative Assembly from Sawantwadi. The latest available result shows Deepak Kesarkar winning the 2024 election from Sawantwadi as a Shiv Sena candidate (WON). The latest record places Deepak Kesarkar in Maharashtra with the Shiv Sena ticket for Sawantwadi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "db97dee8-fa26-45a8-b436-28c0f40bc941",
+    "name": "Shivaji Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Chandgad",
+    "party": "Independent",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Chandgad",
+          "party": "Independent",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Shivaji Patil is a Maharashtra leader and Member of the Legislative Assembly from Chandgad. The latest available result shows Shivaji Patil winning the 2024 election from Chandgad as a Independent candidate (WON). The latest record places Shivaji Patil in Maharashtra with the Independent ticket for Chandgad.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "8effe5e8-65aa-4930-9665-7aa02f92d4ef",
+    "name": "Prakashrao Abitkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Radhanagari",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Radhanagari",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Prakashrao Abitkar is a Maharashtra leader and Member of the Legislative Assembly from Radhanagari. The latest available result shows Prakashrao Abitkar winning the 2024 election from Radhanagari as a Shiv Sena candidate (WON). The latest record places Prakashrao Abitkar in Maharashtra with the Shiv Sena ticket for Radhanagari.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "c8c377e9-f52b-4d98-8908-15f98ca3728d",
+    "name": "Hasan Mushrif",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kagal",
+    "party": "Nationalist Congress Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kagal",
+          "party": "Nationalist Congress Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Hasan Mushrif is a Maharashtra leader and Member of the Legislative Assembly from Kagal. The latest available result shows Hasan Mushrif winning the 2024 election from Kagal as a Nationalist Congress Party candidate (WON). The latest record places Hasan Mushrif in Maharashtra with the Nationalist Congress Party ticket for Kagal.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d0286d84-f720-4ac7-9671-99dbb213e176",
+    "name": "Amal Mahadik",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kolhapur South",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kolhapur South",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Amal Mahadik is a Maharashtra leader and Member of the Legislative Assembly from Kolhapur South. The latest available result shows Amal Mahadik winning the 2024 election from Kolhapur South as a Bharatiya Janata Party candidate (WON). The latest record places Amal Mahadik in Maharashtra with the Bharatiya Janata Party ticket for Kolhapur South.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "738d8cfb-1243-4834-a725-9dcbe20b42e5",
+    "name": "Chandradip Narke",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Karvir",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Karvir",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Chandradip Narke is a Maharashtra leader and Member of the Legislative Assembly from Karvir. The latest available result shows Chandradip Narke winning the 2024 election from Karvir as a Shiv Sena candidate (WON). The latest record places Chandradip Narke in Maharashtra with the Shiv Sena ticket for Karvir.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "859ebdf5-47e0-47e8-b37a-86bad6824177",
+    "name": "Rajesh Kshirsagar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Kolhapur North",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Kolhapur North",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajesh Kshirsagar is a Maharashtra leader and Member of the Legislative Assembly from Kolhapur North. The latest available result shows Rajesh Kshirsagar winning the 2024 election from Kolhapur North as a Shiv Sena candidate (WON). The latest record places Rajesh Kshirsagar in Maharashtra with the Shiv Sena ticket for Kolhapur North.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "15fb5b8c-2852-4afa-b03f-d7a950091c28",
+    "name": "Vinay Kore",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shahuwadi",
+    "party": "Jan Surajya Shakti",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shahuwadi",
+          "party": "Jan Surajya Shakti",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vinay Kore is a Maharashtra leader and Member of the Legislative Assembly from Shahuwadi. The latest available result shows Vinay Kore winning the 2024 election from Shahuwadi as a Jan Surajya Shakti candidate (WON). The latest record places Vinay Kore in Maharashtra with the Jan Surajya Shakti ticket for Shahuwadi.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d3d67727-79d6-4c1d-8573-580b9f140fc5",
+    "name": "Ashokrao Mane",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Hatkanangle (SC)",
+    "party": "Jan Surajya Shakti",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Hatkanangle (SC)",
+          "party": "Jan Surajya Shakti",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Ashokrao Mane is a Maharashtra leader and Member of the Legislative Assembly from Hatkanangle (SC). The latest available result shows Ashokrao Mane winning the 2024 election from Hatkanangle (SC) as a Jan Surajya Shakti candidate (WON). The latest record places Ashokrao Mane in Maharashtra with the Jan Surajya Shakti ticket for Hatkanangle (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a5ce03e8-732a-423e-80c2-9bca57cfda3f",
+    "name": "Rahul Awade",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Ichalkaranji",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Ichalkaranji",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rahul Awade is a Maharashtra leader and Member of the Legislative Assembly from Ichalkaranji. The latest available result shows Rahul Awade winning the 2024 election from Ichalkaranji as a Bharatiya Janata Party candidate (WON). The latest record places Rahul Awade in Maharashtra with the Bharatiya Janata Party ticket for Ichalkaranji.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "9dc003ca-7181-4ce5-9ecc-687868686a30",
+    "name": "Rajendra Patil Yadravkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shirol",
+    "party": "Rajarshi Shahu Vikas Aghadi",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shirol",
+          "party": "Rajarshi Shahu Vikas Aghadi",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rajendra Patil Yadravkar is a Maharashtra leader and Member of the Legislative Assembly from Shirol. The latest available result shows Rajendra Patil Yadravkar winning the 2024 election from Shirol as a Rajarshi Shahu Vikas Aghadi candidate (WON). The latest record places Rajendra Patil Yadravkar in Maharashtra with the Rajarshi Shahu Vikas Aghadi ticket for Shirol.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "d06e1ef7-e820-4a50-b3ce-36fe6843f25f",
+    "name": "Suresh Khade",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Miraj (SC)",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Miraj (SC)",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Suresh Khade is a Maharashtra leader and Member of the Legislative Assembly from Miraj (SC). The latest available result shows Suresh Khade winning the 2024 election from Miraj (SC) as a Bharatiya Janata Party candidate (WON). The latest record places Suresh Khade in Maharashtra with the Bharatiya Janata Party ticket for Miraj (SC).",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "48c0d14c-074a-42c3-9072-c2312e0449ae",
+    "name": "Sudhir Gadgil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Sangli",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Sangli",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Sudhir Gadgil is a Maharashtra leader and Member of the Legislative Assembly from Sangli. The latest available result shows Sudhir Gadgil winning the 2024 election from Sangli as a Bharatiya Janata Party candidate (WON). The latest record places Sudhir Gadgil in Maharashtra with the Bharatiya Janata Party ticket for Sangli.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "a047aeb2-2762-4cf0-b475-e6e933a5b0ef",
+    "name": "Jayant Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Islampur",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Islampur",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Jayant Patil is a Maharashtra leader and Member of the Legislative Assembly from Islampur. The latest available result shows Jayant Patil winning the 2024 election from Islampur as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Jayant Patil in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Islampur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "46dd731c-cdbf-401c-b03e-31584ac6d41d",
+    "name": "Satyajit Deshmukh",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Shirala",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Shirala",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Satyajit Deshmukh is a Maharashtra leader and Member of the Legislative Assembly from Shirala. The latest available result shows Satyajit Deshmukh winning the 2024 election from Shirala as a Bharatiya Janata Party candidate (WON). The latest record places Satyajit Deshmukh in Maharashtra with the Bharatiya Janata Party ticket for Shirala.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "74890e69-dd3e-48ea-b521-e6e05929b3e4",
+    "name": "Vishwajeet Kadam",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Palus-Kadegaon",
+    "party": "Indian National Congress",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Palus-Kadegaon",
+          "party": "Indian National Congress",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Vishwajeet Kadam is a Maharashtra leader and Member of the Legislative Assembly from Palus-Kadegaon. The latest available result shows Vishwajeet Kadam winning the 2024 election from Palus-Kadegaon as a Indian National Congress candidate (WON). The latest record places Vishwajeet Kadam in Maharashtra with the Indian National Congress ticket for Palus-Kadegaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "b1f4ffea-e837-467a-9faf-fba6bf90b1a5",
+    "name": "Suhas Babar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Khanapur",
+    "party": "Shiv Sena",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Khanapur",
+          "party": "Shiv Sena",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Suhas Babar is a Maharashtra leader and Member of the Legislative Assembly from Khanapur. The latest available result shows Suhas Babar winning the 2024 election from Khanapur as a Shiv Sena candidate (WON). The latest record places Suhas Babar in Maharashtra with the Shiv Sena ticket for Khanapur.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "dadba1ba-c29e-4bad-ab14-76101a6291f3",
+    "name": "Rohit Patil",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Tasgaon",
+    "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Tasgaon",
+          "party": "Nationalist Congress Party (Sharadchandra Pawar)",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Rohit Patil is a Maharashtra leader and Member of the Legislative Assembly from Tasgaon. The latest available result shows Rohit Patil winning the 2024 election from Tasgaon as a Nationalist Congress Party (Sharadchandra Pawar) candidate (WON). The latest record places Rohit Patil in Maharashtra with the Nationalist Congress Party (Sharadchandra Pawar) ticket for Tasgaon.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
+  },
+  {
+    "id": "98597ad4-cabb-4f64-bd53-994a71c515cc",
+    "name": "Gopichand Padalkar",
+    "photo": null,
+    "state": "Maharashtra",
+    "constituency": "Jath",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [
+        {
+          "year": 2024,
+          "type": "MLA",
+          "state": "Maharashtra",
+          "constituency": "Jath",
+          "party": "Bharatiya Janata Party",
+          "status": "WON",
+          "citation": {
+            "link": "https://en.wikipedia.org/wiki/2024_Maharashtra_Legislative_Assembly_election#Results_by_district",
+            "source": "OTHERS"
+          }
+        }
+      ],
+      "summary": "Gopichand Padalkar is a Maharashtra leader and Member of the Legislative Assembly from Jath. The latest available result shows Gopichand Padalkar winning the 2024 election from Jath as a Bharatiya Janata Party candidate (WON). The latest record places Gopichand Padalkar in Maharashtra with the Bharatiya Janata Party ticket for Jath.",
+      "summary_citation": null
+    },
+    "notes": null,
+    "lastUpdated": "2026-06-16T12:30:47.165Z"
   }
 ]


### PR DESCRIPTION
  ## What does this PR do?

  Adds all 288 Maharashtra Vidhan Sabha winners from the 2024 election to `app/data/mla.json`, and removes 161 pre-existing Maharashtra
  records that contained hallucinated/false data.

  ## Type of change

  - [x] Data contribution (added/updated MP or MLA records)
  - [ ] New enrichment process (new agent process class)
  - [x] Bug fix
  - [ ] Feature / enhancement
  - [x] Refactor / code cleanup
  - [ ] Documentation update
  - [ ] Other (describe below)

  ## Scope

  - **State/segment:** Maharashtra, MLA (2024 Vidhan Sabha election)
  - **Added:** 288 records (all 2024 winners, status `WON`)
  - **Removed:** 161 records with hallucinated data — e.g. constituencies like "Anandpur Sahib" (actually in Punjab), "Bahrain",
  "Brahmaputra", and placeholder names like "None (... not in Maharashtra)". All 161 had empty election arrays.
  - Source: Wikipedia "2024 Maharashtra Legislative Assembly election → Results by district" (cites ECI results).
  - Each record follows the existing schema: `id` (UUID), `name`, `constituency`, `party`, `state`, `type`, `political_background` (with
  2024 election + summary), etc.

  ## How was this tested?

  Verified the data programmatically against Wikipedia:

  ```bash
  # Re-scraped the Wikipedia results table and compared to the file:
  # - 288 winner rows  ->  288 Maharashtra records (288 unique constituencies)
  # - row-by-row winner + party match: 0 mismatches
  # - party seat totals match Wikipedia exactly:
  #     BJP 132, SHS 57, NCP 41, SS(UBT) 20, INC 16, NCP(SP) 10, + 12 others
  # - all 3,582 non-Maharashtra records confirmed byte-for-byte unchanged

  Note: make test was not run locally (no local DB/venv set up); change is data-only in mla.json.

  Version bump

  - [ ] patch — Bug fixes, small tweaks (0.3.5 → 0.3.6)
  - [x] minor — New features, enhancements (0.3.5 → 0.4.0)
  - [ ] major — Breaking changes (0.3.5 → 1.0.0)

  Checklist

  - [x] I have not committed .env, API keys, or any secrets
  - [x] I have not committed app/database/cache.db
  - [x] I have reviewed the diff and it only contains intended changes
  - [x] Data changes are limited to app/data/mp.json and/or app/data/mla.json
  - [ ] Tests pass locally (make test) — not run; data-only change

   ## Additional notes

  The diff line count looks large only because deleting 161 records from the middle of a big JSON array makes git re-align many identical
  lines — but only Maharashtra records changed (all other records are byte-for-byte identical).