### PR TITLE
feat: add MLA Jayanarayan Mishra (Odisha/Sambalpur)

### DIFF
--- a/app/data/mla.json
+++ b/app/data/mla.json
@@ -100764,5 +100764,26 @@
       "summary_citation": null
     },
     "lastUpdated": "2026-06-06T06:46:27.594Z"
+  },
+  {
+    "id": "071c8bf7-167b-5720-89a4-065f74932a1f",
+    "name": "Jayanarayan Mishra",
+    "photo": null,
+    "state": "Odisha",
+    "constituency": "Sambalpur",
+    "party": "Bharatiya Janata Party",
+    "type": "MLA",
+    "education": null,
+    "family_background": null,
+    "criminal_records": null,
+    "social_media": null,
+    "contact": null,
+    "political_background": {
+      "elections": [],
+      "summary": "Jayanarayan Mishra is an Odisha leader and Member of the Legislative Assembly from Sambalpur. He is a senior Bharatiya Janata Party leader who has served multiple terms representing the Sambalpur constituency in the Odisha Legislative Assembly.",
+      "summary_citation": null
+    },
+    "notes": "Added via community request (GitHub issue #227). Constituency maps to pincode 768016 area (Bargarh/Sambalpur region, Odisha).",
+    "lastUpdated": "2026-06-25T10:30:00.000Z"
   }
 ]


### PR DESCRIPTION
## Summary

Resolves #227 — community request by @Ashutosh3021 to add MLA Jayanarayan Mishra for pincode 768016 (Bargarh/Sambalpur region, Odisha).

- Adds a new MLA record for **Jayanarayan Mishra** (BJP, Sambalpur constituency, Odisha) to `app/data/mla.json`
- Record includes a basic political summary; full enrichment (education, election history, criminal records, social media) can be run via `python scripts/run_politician_agent.py --id 071c8bf7-167b-5720-89a4-065f74932a1f`
- Deterministic UUID generated using the project's `uuid5(NAMESPACE_DNS, name|state|constituency)` pattern

## Test plan

- [ ] Verify record appears at `/api/v1/politicians?type=MLA&state=Odisha`
- [ ] Verify profile page renders at `/politicians/jayanarayan-mishra` (or with short-id suffix)
- [ ] Run enrichment agent to populate election history and citations
- [ ] Confirm JSON is valid: `python scripts/validate_json.py`

---

Hey @Ashutosh3021 — your requested MLA has been added! 🎉 Could you please take a quick look and confirm the details look right? If the constituency or party needs any correction, let us know in the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zd7sq1EcpT8DFGqqwVc41

---
_Generated by [Claude Code](https://claude.ai/code/session_015zd7sq1EcpT8DFGqqwVc41)_