### PR TITLE
Replace deprecated gemini-2.5-flash with gemini-3.5-flash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ DB_ECHO=false
 AGENT_LLM_PROVIDERS=gemini,perplexity,openai
 
 GEMINI_API_KEY=
-GEMINI_MODEL=gemini-2.5-flash
+GEMINI_MODEL=gemini-3.5-flash
 
 PERPLEXITY_API_KEY=
 AGENT_PERPLEXITY_MODEL=sonar

--- a/app/config/free_tier_llm.py
+++ b/app/config/free_tier_llm.py
@@ -15,7 +15,7 @@ Usage:
 
     # Or bring your own config:
     llm = FreeTierLLM.from_env(configs=[
-        {"provider": "gemini", "model": "gemini-2.5-flash", "api_key_env": "GEMINI_API_KEY"},
+        {"provider": "gemini", "model": "gemini-3.5-flash", "api_key_env": "GEMINI_API_KEY"},
     ])
 """
 
@@ -101,7 +101,7 @@ DEFAULT_PROVIDERS: list[dict[str, Any]] = [
     # --- Gemini (generous free tier) ---
     {
         "provider": "gemini",
-        "model": "gemini-2.5-flash",
+        "model": "gemini-3.5-flash",
         "api_key_env": "GEMINI_API_KEY",
     },
     # {"provider": "gemini", "model": "gemini-2.5-pro", "api_key_env": "GEMINI_API_KEY"},

--- a/docs/free-tier-wrapper-mvp.md
+++ b/docs/free-tier-wrapper-mvp.md
@@ -81,7 +81,7 @@ Edit `DEFAULT_PROVIDERS` in `free_tier_llm.py` or pass a custom config:
 
 ```python
 my_configs = [
-    {"provider": "gemini", "model": "gemini-2.5-flash", "api_key_env": "GEMINI_API_KEY"},
+    {"provider": "gemini", "model": "gemini-3.5-flash", "api_key_env": "GEMINI_API_KEY"},
     {"provider": "groq", "model": "llama-3.3-70b-versatile", "api_key_env": "GROQ_API_KEY",
      "base_url": "https://api.groq.com/openai/v1"},
     {"provider": "cerebras", "model": "llama3.1-8b", "api_key_env": "CEREBRAS_API_KEY",
@@ -148,10 +148,10 @@ llm = FreeTierLLM.from_env()
 # ... after some usage ...
 print(llm.status())
 # {
-#   "active": "gemini-2.5-flash",
+#   "active": "gemini-3.5-flash",
 #   "models": [
 #     {"provider": "gemini", "model": "gemini-2.5-pro-preview-05-06", "state": "exhausted"},
-#     {"provider": "gemini", "model": "gemini-2.5-flash", "state": "available"},
+#     {"provider": "gemini", "model": "gemini-3.5-flash", "state": "available"},
 #     {"provider": "groq",  "model": "llama-3.3-70b-versatile", "state": "cooldown (42s)"},
 #     ...
 #   ]

--- a/tests/unit/config/test_free_tier_llm.py
+++ b/tests/unit/config/test_free_tier_llm.py
@@ -216,7 +216,7 @@ class TestFreeTierLLMFactory:
         test_configs = [
             {
                 "provider": "gemini",
-                "model": "gemini-2.5-flash",
+                "model": "gemini-3.5-flash",
                 "api_key_env": "GEMINI_API_KEY",
             },
             {
@@ -277,7 +277,7 @@ class TestProviderConfig:
         cfg = ProviderConfig.from_dict(
             {
                 "provider": "gemini",
-                "model": "gemini-2.5-flash",
+                "model": "gemini-3.5-flash",
                 "api_key_env": "GEMINI_API_KEY",
             }
         )


### PR DESCRIPTION
## What does this PR do?

Replaces the deprecated `gemini-2.5-flash` model with `gemini-3.5-flash` in the default configuration, documentation, environment example, and related unit tests.

Fixes #235

## Type of change

- [ ] Data contribution (added/updated MP or MLA records)
- [ ] New enrichment process (new agent process class)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Refactor / code cleanup
- [x] Documentation update
- [ ] Other (describe below)

## Scope

Updated:

- `.env.example`
- `app/config/free_tier_llm.py`
- `docs/free-tier-wrapper-mvp.md`
- `tests/unit/config/test_free_tier_llm.py`

## How was this tested?

```bash
python -m pytest tests/unit
```

Result:

- 227 tests passed locally.

## Version bump

- [x] `patch`
- [ ] `minor`
- [ ] `major`

## Checklist

- [x] I have **not** committed `.env`, API keys, or any secrets
- [x] I have **not** committed `app/database/cache.db`
- [x] I have reviewed the diff and it only contains intended changes
- [ ] Data changes are limited to `app/data/mp.json` and/or `app/data/mla.json`
- [x] Tests pass locally

## Additional notes

Updates the default Gemini Flash model to `gemini-3.5-flash` to resolve the 404 issue reported in #235.